### PR TITLE
cmd/kni-install - exit after bootstrap launch

### DIFF
--- a/cmd/kni-install/create.go
+++ b/cmd/kni-install/create.go
@@ -104,7 +104,8 @@ var (
 					logrus.Fatal(errors.Wrap(err, "loading kubeconfig"))
 				}
 
-				logrus.Warn("FIXME!")
+				logrus.Warn("FIXME! Exiting after bootstrap cluster create for baremetal testing")
+				return
 
 				err = destroyBootstrap(ctx, config, rootOpts.dir)
 				if err != nil {


### PR DESCRIPTION
Temporary hack to exit after we launch the bootstrap VM, so
we can continue to use the dev-scripts logic to launch the
masters etc as an interim step.

This is needed for end-to-end testing of https://github.com/metalkube/dev-scripts/pull/93