### PR TITLE
baremetal: prefix resources with cluster_id

### DIFF
--- a/data/data/baremetal/bootstrap/README.md
+++ b/data/data/baremetal/bootstrap/README.md
@@ -29,7 +29,7 @@ module "bootstrap" {
 
   addresses      = ["192.168.0.1"]
   base_volume_id = "${libvirt_volume.example.id}"
-  cluster_name   = "my-cluster"
+  cluster_id     = "my-cluster"
   ignition       = "{\"ignition\": {\"version\": \"2.2.0\"}}",
   network_id     = "${libvirt_network.example.id}"
 }

--- a/data/data/baremetal/bootstrap/main.tf
+++ b/data/data/baremetal/bootstrap/main.tf
@@ -1,15 +1,15 @@
 resource "libvirt_volume" "bootstrap" {
-  name           = "${var.cluster_name}-bootstrap"
+  name           = "${var.cluster_id}-bootstrap"
   base_volume_id = "${var.base_volume_id}"
 }
 
 resource "libvirt_ignition" "bootstrap" {
-  name    = "${var.cluster_name}-bootstrap.ign"
+  name    = "${var.cluster_id}-bootstrap.ign"
   content = "${var.ignition}"
 }
 
 resource "libvirt_domain" "bootstrap" {
-  name = "${var.cluster_name}-bootstrap"
+  name = "${var.cluster_id}-bootstrap"
 
   memory = "4096"
 

--- a/data/data/baremetal/bootstrap/variables.tf
+++ b/data/data/baremetal/bootstrap/variables.tf
@@ -3,9 +3,9 @@ variable "base_volume_id" {
   description = "The ID of the base volume for the bootstrap node."
 }
 
-variable "cluster_name" {
+variable "cluster_id" {
   type        = "string"
-  description = "The name of the cluster."
+  description = "The identifier for the cluster."
 }
 
 variable "ignition" {

--- a/data/data/baremetal/main.tf
+++ b/data/data/baremetal/main.tf
@@ -1,7 +1,3 @@
-locals {
-  cluster_domain = "${var.cluster_name}.${var.base_domain}"
-}
-
 provider "libvirt" {
   uri = "${var.libvirt_uri}"
 }
@@ -9,15 +5,15 @@ provider "libvirt" {
 module "volume" {
   source = "./volume"
 
-  cluster_name = "${var.cluster_name}"
-  image        = "${var.os_image}"
+  cluster_id = "${var.cluster_id}"
+  image      = "${var.os_image}"
 }
 
 module "bootstrap" {
   source = "./bootstrap"
 
   base_volume_id   = "${module.volume.coreos_base_volume_id}"
-  cluster_name     = "${var.cluster_name}"
+  cluster_id       = "${var.cluster_id}"
   ignition         = "${var.ignition_bootstrap}"
   baremetal_bridge = "${var.baremetal_bridge}"
   overcloud_bridge = "${var.overcloud_bridge}"

--- a/data/data/baremetal/volume/main.tf
+++ b/data/data/baremetal/volume/main.tf
@@ -1,4 +1,4 @@
 resource "libvirt_volume" "coreos_base" {
-  name   = "${var.cluster_name}-base"
+  name   = "${var.cluster_id}-base"
   source = "${var.image}"
 }

--- a/data/data/baremetal/volume/variables.tf
+++ b/data/data/baremetal/volume/variables.tf
@@ -1,6 +1,6 @@
-variable "cluster_name" {
+variable "cluster_id" {
   type        = "string"
-  description = "The name of the cluster."
+  description = "The identifier for the cluster."
 }
 
 variable "image" {


### PR DESCRIPTION
As per openshift/installer#1280 cluster_id is now used to prefix resources in other providers rather than cluster_name.