### PR TITLE
baremetal: avoid separate base image for bootstrap

### DIFF
--- a/data/data/baremetal/bootstrap/main.tf
+++ b/data/data/baremetal/bootstrap/main.tf
@@ -1,6 +1,6 @@
 resource "libvirt_volume" "bootstrap" {
-  name           = "${var.cluster_id}-bootstrap"
-  base_volume_id = "${var.base_volume_id}"
+  name   = "${var.cluster_id}-bootstrap"
+  source = "${var.image}"
 }
 
 resource "libvirt_ignition" "bootstrap" {

--- a/data/data/baremetal/bootstrap/variables.tf
+++ b/data/data/baremetal/bootstrap/variables.tf
@@ -1,11 +1,11 @@
-variable "base_volume_id" {
-  type        = "string"
-  description = "The ID of the base volume for the bootstrap node."
-}
-
 variable "cluster_id" {
   type        = "string"
   description = "The identifier for the cluster."
+}
+
+variable "image" {
+  description = "The URL of the OS disk image"
+  type        = "string"
 }
 
 variable "ignition" {

--- a/data/data/baremetal/main.tf
+++ b/data/data/baremetal/main.tf
@@ -2,18 +2,11 @@ provider "libvirt" {
   uri = "${var.libvirt_uri}"
 }
 
-module "volume" {
-  source = "./volume"
-
-  cluster_id = "${var.cluster_id}"
-  image      = "${var.os_image}"
-}
-
 module "bootstrap" {
   source = "./bootstrap"
 
-  base_volume_id   = "${module.volume.coreos_base_volume_id}"
   cluster_id       = "${var.cluster_id}"
+  image            = "${var.os_image}"
   ignition         = "${var.ignition_bootstrap}"
   baremetal_bridge = "${var.baremetal_bridge}"
   overcloud_bridge = "${var.overcloud_bridge}"

--- a/data/data/baremetal/volume/main.tf
+++ b/data/data/baremetal/volume/main.tf
@@ -1,4 +1,0 @@
-resource "libvirt_volume" "coreos_base" {
-  name   = "${var.cluster_id}-base"
-  source = "${var.image}"
-}

--- a/data/data/baremetal/volume/outputs.tf
+++ b/data/data/baremetal/volume/outputs.tf
@@ -1,3 +1,0 @@
-output "coreos_base_volume_id" {
-  value = "${libvirt_volume.coreos_base.id}"
-}

--- a/data/data/baremetal/volume/variables.tf
+++ b/data/data/baremetal/volume/variables.tf
@@ -1,9 +1,0 @@
-variable "cluster_id" {
-  type        = "string"
-  description = "The identifier for the cluster."
-}
-
-variable "image" {
-  description = "The URL of the OS disk image"
-  type        = "string"
-}


### PR DESCRIPTION
The libvirt platform driver creates a base volume, and then creates
copy-on-write volumes for various VMs it creates.

The baremetal platform driver only creates a single libvirt VM, so it
does not need this additional layer.

This fixes "destroy bootstrap" not cleaning up the base image. The
base image resource is owned by module.volume, but "destroy boostrap"
only destroys the resources in module.bootstrap. This makes sense for
the libvirt platform, but not for the baremetal platform.