### PR TITLE
baremetal: enable keepalived

### DIFF
--- a/pkg/asset/ignition/bootstrap/bootstrap.go
+++ b/pkg/asset/ignition/bootstrap/bootstrap.go
@@ -247,6 +247,7 @@ func (a *Bootstrap) addSystemdUnits(uri string, templateData *bootstrapTemplateD
 	enabled := map[string]struct{}{
 		"progress.service":                {},
 		"kubelet.service":                 {},
+		"keepalived.service":              {},
 		"systemd-journal-gatewayd.socket": {},
 	}
 


### PR DESCRIPTION
Turns out there's a hardcoded list of systemd units to enable.