### PR TITLE
Make sure we only return a single dev

### DIFF
--- a/data/data/bootstrap/files/usr/local/bin/keepalived.sh
+++ b/data/data/bootstrap/files/usr/local/bin/keepalived.sh
@@ -13,7 +13,7 @@ API_DNS="$(sudo awk -F[/:] '/apiServerURL/ {print $5}' /opt/openshift/manifests/
 API_VIP="$(dig +noall +answer "$API_DNS" | awk '{print $NF}')"
 IFACE_CIDRS="$(ip addr show | grep -v "scope host" | grep -Po 'inet \K[\d.]+/[\d.]+' | xargs)"
 SUBNET_CIDR="$(/usr/local/bin/get_vip_subnet_cidr "$API_VIP" "$IFACE_CIDRS")"
-INTERFACE="$(ip -o addr show to "$SUBNET_CIDR" | awk '{print $2}')"
+INTERFACE="$(ip -o addr show to "$SUBNET_CIDR" | head -n 1 | awk '{print $2}')"
 DNS_VIP="$(/usr/local/bin/nthhost "$SUBNET_CIDR" 2)"
 
 export API_VIP


### PR DESCRIPTION
In cases where a nic has two ipaddresses on the same externel
subnet then "ip -o addr show" returns a row for each one. Make
sure we only attempt to use one.

Was hitting a problem on a bootstrap not that has 2 IPs on the same subnet