### PR TITLE
Integrate coredns with the mdns plugin

### DIFF
--- a/data/data/bootstrap/files/etc/coredns/Corefile
+++ b/data/data/bootstrap/files/etc/coredns/Corefile
@@ -1,0 +1,8 @@
+. {
+    errors
+    health
+    mdns {$CLUSTER_DOMAIN}
+    forward . /etc/coredns/resolv.conf
+    cache 30
+    reload
+}

--- a/data/data/bootstrap/files/etc/keepalived/keepalived.conf.tmpl
+++ b/data/data/bootstrap/files/etc/keepalived/keepalived.conf.tmpl
@@ -1,4 +1,4 @@
-vrrp_instance VI_1 {
+vrrp_instance API {
     state BACKUP
     interface ${INTERFACE}
     virtual_router_id 51
@@ -6,9 +6,24 @@ vrrp_instance VI_1 {
     advert_int 1
     authentication {
         auth_type PASS
-        auth_pass cluster_uuid_master_vip
+        auth_pass cluster_uuid_api_vip
     }
     virtual_ipaddress {
-        ${MASTER_VIP}
+        ${API_VIP}
+    }
+}
+
+vrrp_instance DNS {
+    state BACKUP
+    interface ${INTERFACE}
+    virtual_router_id 52
+    priority 50
+    advert_int 1
+    authentication {
+        auth_type PASS
+        auth_pass cluster_uuid_dns_vip
+    }
+    virtual_ipaddress {
+        ${DNS_VIP}
     }
 }

--- a/data/data/bootstrap/files/usr/local/bin/coredns.sh
+++ b/data/data/bootstrap/files/usr/local/bin/coredns.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -e
+
+
+mkdir --parents /etc/keepalived
+
+API_DNS="$(sudo awk -F[/:] '/apiServerURL/ {print $5}' /opt/openshift/manifests/cluster-infrastructure-02-config.yml)"
+CLUSTER_DOMAIN="${API_DNS#*.}"
+API_VIP="$(dig +noall +answer "$API_DNS" | awk '{print $NF}')"
+IFACE_CIDRS="$(ip addr show | grep -v "scope host" | grep -Po 'inet \K[\d.]+/[\d.]+' | xargs)"
+SUBNET_CIDR="$(/usr/local/bin/get_vip_subnet_cidr "$API_VIP" "$IFACE_CIDRS")"
+DNS_VIP="$(/usr/local/bin/nthhost "$SUBNET_CIDR" 2)"
+grep -v "${DNS_VIP}" /etc/resolv.conf | tee /etc/coredns/resolv.conf
+
+COREDNS_IMAGE="quay.io/openshift-metalkube/coredns:latest"
+if ! podman inspect "$COREDNS_IMAGE" &>/dev/null; then
+    echo "Pulling release image..."
+    podman pull "$COREDNS_IMAGE"
+fi
+MATCHES="$(sudo podman ps -a --format "{{.Names}}" | awk '/coredns$/ {print $0}')"
+if [[ -z "$MATCHES" ]]; then
+    /usr/bin/podman create \
+        --name coredns \
+        --volume /etc/coredns:/etc/coredns:z \
+        --network host \
+        --env CLUSTER_DOMAIN="$CLUSTER_DOMAIN" \
+        "${COREDNS_IMAGE}" \
+            --conf /etc/coredns/Corefile
+fi

--- a/data/data/bootstrap/files/usr/local/bin/get_vip_subnet_cidr
+++ b/data/data/bootstrap/files/usr/local/bin/get_vip_subnet_cidr
@@ -1,0 +1,24 @@
+#!/usr/bin/env python
+import sys
+import socket
+import struct
+
+vip = sys.argv[1]
+iface_cidrs = sys.argv[2].split()
+vip_int = struct.unpack("!I", socket.inet_aton(vip))[0]
+
+for iface_cidr in iface_cidrs:
+    ip, prefix = iface_cidr.split('/')
+    ip_int = struct.unpack("!I", socket.inet_aton(ip))[0]
+    prefix_int = int(prefix)
+    mask = int('1' * prefix_int + '0' * (32 - prefix_int), 2)
+    subnet_ip_int_min = ip_int & mask
+    subnet_ip = socket.inet_ntoa(struct.pack("!I", subnet_ip_int_min))
+    subnet_ip_int_max = subnet_ip_int_min | int('1' * (32 - prefix_int), 2)
+    subnet_ip_max = socket.inet_ntoa(struct.pack("!I", subnet_ip_int_max))
+    sys.stderr.write('Is %s between %s and %s\n' % (vip, subnet_ip, subnet_ip_max))
+    if subnet_ip_int_min < vip_int < subnet_ip_int_max:
+        subnet_ip = socket.inet_ntoa(struct.pack("!I", subnet_ip_int_min))
+        print('%s/%s' % (subnet_ip, prefix))
+        sys.exit(0)
+sys.exit(1)

--- a/data/data/bootstrap/files/usr/local/bin/keepalived.sh
+++ b/data/data/bootstrap/files/usr/local/bin/keepalived.sh
@@ -1,62 +1,36 @@
 #!/usr/bin/env bash
 set -e
 
-function get_iface_in_vip_subnet() {
-    local vip
-    local net_cidr
-    local iface_cidrs
-
-    vip="$1"
-
-    iface_cidrs=$(ip addr show | grep -v "scope host" | grep -Po 'inet \K[\d.]+/[\d.]+' | xargs)
-    net_cidr=$(/usr/bin/env python - "$vip" "$iface_cidrs" << EOF
-import sys
-import socket
-import struct
-
-vip = sys.argv[1]
-iface_cidrs = sys.argv[2].split()
-vip_int = struct.unpack("!I", socket.inet_aton(vip))[0]
-
-for iface_cidr in iface_cidrs:
-    ip, prefix = iface_cidr.split('/')
-    ip_int = struct.unpack("!I", socket.inet_aton(ip))[0]
-    prefix_int = int(prefix)
-    mask = int('1' * prefix_int + '0' * (32 - prefix_int), 2)
-    subnet_ip_int_min = ip_int & mask
-    subnet_ip = socket.inet_ntoa(struct.pack("!I", subnet_ip_int_min))
-    subnet_ip_int_max = subnet_ip_int_min | int('1' * (32 - prefix_int), 2)
-    subnet_ip_max = socket.inet_ntoa(struct.pack("!I", subnet_ip_int_max))
-    sys.stderr.write('Is %s between %s and %s\n' % (vip, subnet_ip, subnet_ip_max))
-    if subnet_ip_int_min < vip_int < subnet_ip_int_max:
-        subnet_ip = socket.inet_ntoa(struct.pack("!I", subnet_ip_int_min))
-        print('%s/%s' % (subnet_ip, prefix))
-        sys.exit(0)
-sys.exit(1)
-EOF
-)
-    ip -o addr show to "$net_cidr" | awk '{print $2}'
-}
-
 mkdir --parents /etc/keepalived
 
-KEEPALIVED_IMAGE=registry.access.redhat.com/rhosp14/openstack-keepalived:14.0
+KEEPALIVED_IMAGE=quay.io/celebdor/keepalived:latest
 if ! podman inspect "$KEEPALIVED_IMAGE" &>/dev/null; then
     echo "Pulling release image..."
     podman pull "$KEEPALIVED_IMAGE"
 fi
 
-API_DNS=$(sudo awk -F[/:] '/apiServerURL/ {print $5}' /opt/openshift/manifests/cluster-infrastructure-02-config.yml)
-export MASTER_VIP=$(dig +noall +answer "$API_DNS" | awk '{print $NF}')
-env INTERFACE=$(get_iface_in_vip_subnet "$MASTER_VIP") envsubst < /etc/keepalived/keepalived.conf.tmpl > /etc/keepalived/keepalived.conf
+API_DNS="$(sudo awk -F[/:] '/apiServerURL/ {print $5}' /opt/openshift/manifests/cluster-infrastructure-02-config.yml)"
+API_VIP="$(dig +noall +answer "$API_DNS" | awk '{print $NF}')"
+IFACE_CIDRS="$(ip addr show | grep -v "scope host" | grep -Po 'inet \K[\d.]+/[\d.]+' | xargs)"
+SUBNET_CIDR="$(/usr/local/bin/get_vip_subnet_cidr "$API_VIP" "$IFACE_CIDRS")"
+INTERFACE="$(ip -o addr show to "$SUBNET_CIDR" | awk '{print $2}')"
+DNS_VIP="$(/usr/local/bin/nthhost "$SUBNET_CIDR" 2)"
 
-podman run \
-        --rm \
-        --volume /etc/keepalived:/etc/keepalived:z \
-        --network=host \
-        --cap-add=NET_ADMIN \
-        "${KEEPALIVED_IMAGE}" \
-        /usr/sbin/keepalived -f /etc/keepalived/keepalived.conf --dont-fork -D -l -P
+export API_VIP
+export INTERFACE
+export DNS_VIP
+envsubst < /etc/keepalived/keepalived.conf.tmpl | sudo tee /etc/keepalived/keepalived.conf
 
-# Workaround for https://github.com/opencontainers/runc/pull/1807
-touch /etc/keepalived/.keepalived.done
+MATCHES="$(sudo podman ps -a --format "{{.Names}}" | awk '/keepalived$/ {print $0}')"
+if [[ -z "$MATCHES" ]]; then
+    # TODO(bnemec): Figure out how to run with less perms
+    podman create \
+            --name keepalived \
+            --volume /etc/keepalived:/etc/keepalived:z \
+            --network=host \
+            --privileged \
+            --cap-add=ALL \
+            "${KEEPALIVED_IMAGE}" \
+            /usr/sbin/keepalived -f /etc/keepalived/keepalived.conf \
+                --dont-fork -D -l -P
+fi

--- a/data/data/bootstrap/files/usr/local/bin/nthhost
+++ b/data/data/bootstrap/files/usr/local/bin/nthhost
@@ -1,0 +1,20 @@
+#!/usr/bin/env python
+import sys
+import socket
+import struct
+
+subnet_cidr = sys.argv[1]
+nth = int(sys.argv[2], 10)
+
+# Make sure we get the proper subnet id ip
+ip, prefix_s = subnet_cidr.split('/')
+prefix = int(prefix_s)
+subnet_bits = 32 - prefix
+mask = int('1' * prefix + '0' * subnet_bits, 2)
+ip_int = struct.unpack("!I", socket.inet_aton(ip))[0]
+subnet_id_ip = ip_int & mask
+
+# The DNS VIP is the second host address of the subnet
+summand = nth if nth > 0 else 2 ** subnet_bits + nth
+print(socket.inet_ntoa(struct.pack("!I", subnet_id_ip + summand)))
+sys.exit(0)

--- a/data/data/bootstrap/systemd/units/coredns.service
+++ b/data/data/bootstrap/systemd/units/coredns.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Serve cluster DNS gathered from mDNS
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+WorkingDirectory=/etc/coredns
+ExecStartPre=/usr/local/bin/coredns.sh
+ExecStart=/usr/bin/podman start -a coredns
+ExecStop=/usr/bin/podman stop -t 10 coredns
+
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target

--- a/data/data/bootstrap/systemd/units/keepalived.service
+++ b/data/data/bootstrap/systemd/units/keepalived.service
@@ -2,11 +2,12 @@
 Description=Manage node VIPs with keepalived
 Wants=network-online.target
 After=network-online.target
-ConditionPathExists=!/etc/keepalived/.keepalived.done
 
 [Service]
 WorkingDirectory=/etc/keepalived
-ExecStart=/usr/local/bin/keepalived.sh
+ExecStartPre=/usr/local/bin/keepalived.sh
+ExecStart=/usr/bin/podman start -a keepalived
+ExecStop=/usr/bin/podman stop -t 10 keepalived
 
 Restart=on-failure
 RestartSec=5

--- a/pkg/asset/ignition/bootstrap/bootstrap.go
+++ b/pkg/asset/ignition/bootstrap/bootstrap.go
@@ -251,6 +251,7 @@ func (a *Bootstrap) addSystemdUnits(uri string, templateData *bootstrapTemplateD
 		"progress.service":                {},
 		"kubelet.service":                 {},
 		"keepalived.service":              {},
+		"coredns.service":                 {},
 		"systemd-journal-gatewayd.socket": {},
 	}
 


### PR DESCRIPTION
This patch makes the bootstrap have:
* Keepalived continue to manage the API VIP, but on a macvlan device
* Keepalived manage the DNS VIP on a macvlan device
* CoreDNS serving the cluster node DNS entries by mDNS browsing