### PR TITLE
WIP create: wait for bootstrap-complete before exit

### DIFF
--- a/cmd/kni-install/create.go
+++ b/cmd/kni-install/create.go
@@ -104,13 +104,13 @@ var (
 					logrus.Fatal(errors.Wrap(err, "loading kubeconfig"))
 				}
 
-				logrus.Warn("FIXME! Exiting after bootstrap cluster create for baremetal testing")
-				return
-
 				err = waitForBootstrapComplete(ctx, config, rootOpts.dir)
 				if err != nil {
 					logrus.Fatal(err)
 				}
+
+				logrus.Warn("FIXME! Exiting after bootstrap cluster create for baremetal testing")
+				return
 
 				logrus.Info("Destroying the bootstrap resources...")
 				err = destroybootstrap.Destroy(rootOpts.dir)


### PR DESCRIPTION
This should just work, but I'm getting:

```
level=info msg="Waiting up to 30m0s for the Kubernetes API at https://api.ostest.test.metalkube.org:6443..."
level=debug msg="Still waiting for the Kubernetes API: Get https://api.ostest.test.metalkube.org:6443/version?timeout=32s: x509: certificate signed by unknown authority (possibly because of \"crypto/rsa: verification error\" while trying to verify candidate authority certificate \"kube-ca\")"
level=debug msg="Still waiting for the Kubernetes API: Get https://api.ostest.test.metalkube.org:6443/version?timeout=32s: x509: certificate signed by unknown authority (possibly because of \"crypto/rsa: verification error\" while trying to verify candidate authority certificate \"kube-ca\")"
```