### PR TITLE
bootstrap resolv.conf to use own coredns-mdns

### DIFF
--- a/data/data/bootstrap/files/etc/dhcp/dhclient.conf
+++ b/data/data/bootstrap/files/etc/dhcp/dhclient.conf
@@ -1,0 +1,1 @@
+prepend domain-name-servers 127.0.0.1;


### PR DESCRIPTION
In order for the clustering to work, the bootstrap node should be able
to resolve the SRV records for Etcd. In order to do that, the best is to
prepend localhost to /etc/resolv.conf so that as soon coredns-mdns is
ready, we will be able to use it to get the master entries.