### PR TITLE
Increase timeout for services that download content

### DIFF
--- a/data/data/bootstrap/systemd/units/coredns.service
+++ b/data/data/bootstrap/systemd/units/coredns.service
@@ -11,6 +11,7 @@ ExecStop=/usr/bin/podman stop -t 10 coredns
 
 Restart=on-failure
 RestartSec=5
+TimeoutStartSec=600
 
 [Install]
 WantedBy=multi-user.target

--- a/data/data/bootstrap/systemd/units/keepalived.service
+++ b/data/data/bootstrap/systemd/units/keepalived.service
@@ -11,6 +11,7 @@ ExecStop=/usr/bin/podman stop -t 10 keepalived
 
 Restart=on-failure
 RestartSec=5
+TimeoutStartSec=600
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
When testing that with a slow connection, the services keep
restarting because they don't have enough time to download the
content. Increasing the timeout to, at least 10 minutes, ensures
that will work on more environments.