### PR TITLE
keepalived: separate by cluster

### DIFF
--- a/data/data/bootstrap/files/etc/keepalived/keepalived.conf.tmpl
+++ b/data/data/bootstrap/files/etc/keepalived/keepalived.conf.tmpl
@@ -1,27 +1,27 @@
-vrrp_instance API {
+vrrp_instance ${CLUSTER_NAME}_API {
     state BACKUP
     interface ${INTERFACE}
-    virtual_router_id 51
+    virtual_router_id ${API_VRID}
     priority 50
     advert_int 1
     authentication {
         auth_type PASS
-        auth_pass cluster_uuid_api_vip
+        auth_pass ${CLUSTER_NAME}_api_vip
     }
     virtual_ipaddress {
         ${API_VIP}
     }
 }
 
-vrrp_instance DNS {
+vrrp_instance ${CLUSTER_NAME}_DNS {
     state BACKUP
     interface ${INTERFACE}
-    virtual_router_id 52
+    virtual_router_id ${DNS_VRID}
     priority 50
     advert_int 1
     authentication {
         auth_type PASS
-        auth_pass cluster_uuid_dns_vip
+        auth_pass ${CLUSTER_NAME}_dns_vip
     }
     virtual_ipaddress {
         ${DNS_VIP}

--- a/data/data/bootstrap/files/usr/local/bin/fletcher8
+++ b/data/data/bootstrap/files/usr/local/bin/fletcher8
@@ -1,0 +1,10 @@
+#!/usr/libexec/platform-python
+import sys
+
+data = map(ord, sys.argv[1])
+ckA = ckB = 0
+
+for b in data:
+    ckA = (ckA + b) & 0xf
+    ckB = (ckB + ckA) & 0xf
+print((ckB << 4) | ckA )

--- a/data/data/bootstrap/files/usr/local/bin/keepalived.sh
+++ b/data/data/bootstrap/files/usr/local/bin/keepalived.sh
@@ -10,6 +10,7 @@ if ! podman inspect "$KEEPALIVED_IMAGE" &>/dev/null; then
 fi
 
 API_DNS="$(sudo awk -F[/:] '/apiServerURL/ {print $5}' /opt/openshift/manifests/cluster-infrastructure-02-config.yml)"
+CLUSTER_NAME="$(awk -F. '{print $2}' <<< "$API_DNS")"
 API_VIP="$(dig +noall +answer "$API_DNS" | awk '{print $NF}')"
 IFACE_CIDRS="$(ip addr show | grep -v "scope host" | grep -Po 'inet \K[\d.]+/[\d.]+' | xargs)"
 SUBNET_CIDR="$(/usr/local/bin/get_vip_subnet_cidr "$API_VIP" "$IFACE_CIDRS")"
@@ -17,9 +18,16 @@ INTERFACE="$(ip -o addr show to "$SUBNET_CIDR" | head -n 1 | awk '{print $2}')"
 CLUSTER_DOMAIN="${API_DNS#*.}"
 DNS_VIP="$(dig +noall +answer "ns1.${CLUSTER_DOMAIN}" | awk '{print $NF}')"
 
+# Virtual Router IDs. They must be different and 8 bit in length
+API_VRID=$(/usr/local/bin/fletcher8 "$CLUSTER_NAME-api")
+DNS_VRID=$(/usr/local/bin/fletcher8 "$CLUSTER_NAME-dns")
+
 export API_VIP
+export CLUSTER_NAME
 export INTERFACE
 export DNS_VIP
+export API_VRID
+export DNS_VRID
 envsubst < /etc/keepalived/keepalived.conf.tmpl | sudo tee /etc/keepalived/keepalived.conf
 
 MATCHES="$(sudo podman ps -a --format "{{.Names}}" | awk '/keepalived$/ {print $0}')"


### PR DESCRIPTION
This will allow multiple clusters in a single broadcast domain to
function without keepalived VRRP tripping each other.