### PR TITLE
Use name-filter branch in bootstrap node too

### DIFF
--- a/data/data/bootstrap/files/etc/coredns/Corefile
+++ b/data/data/bootstrap/files/etc/coredns/Corefile
@@ -1,7 +1,7 @@
 . {
     errors
     health
-    mdns {$CLUSTER_DOMAIN}
+    mdns {$CLUSTER_DOMAIN} 3 {$CLUSTER_NAME}
     forward . /etc/coredns/resolv.conf
     cache 30
     reload

--- a/data/data/bootstrap/files/usr/local/bin/coredns.sh
+++ b/data/data/bootstrap/files/usr/local/bin/coredns.sh
@@ -6,13 +6,15 @@ mkdir --parents /etc/keepalived
 
 API_DNS="$(sudo awk -F[/:] '/apiServerURL/ {print $5}' /opt/openshift/manifests/cluster-infrastructure-02-config.yml)"
 CLUSTER_DOMAIN="${API_DNS#*.}"
+read -d '.' -a CLUSTER_ARR <<< $CLUSTER_DOMAIN
+CLUSTER_NAME=${CLUSTER_ARR[0]}
 API_VIP="$(dig +noall +answer "$API_DNS" | awk '{print $NF}')"
 IFACE_CIDRS="$(ip addr show | grep -v "scope host" | grep -Po 'inet \K[\d.]+/[\d.]+' | xargs)"
 SUBNET_CIDR="$(/usr/local/bin/get_vip_subnet_cidr "$API_VIP" "$IFACE_CIDRS")"
 DNS_VIP="$(/usr/local/bin/nthhost "$SUBNET_CIDR" 2)"
 grep -v "${DNS_VIP}" /etc/resolv.conf | tee /etc/coredns/resolv.conf
 
-COREDNS_IMAGE="quay.io/openshift-metalkube/coredns:latest"
+COREDNS_IMAGE="quay.io/openshift-metalkube/coredns-mdns:name-filter"
 if ! podman inspect "$COREDNS_IMAGE" &>/dev/null; then
     echo "Pulling release image..."
     podman pull "$COREDNS_IMAGE"
@@ -24,6 +26,7 @@ if [[ -z "$MATCHES" ]]; then
         --volume /etc/coredns:/etc/coredns:z \
         --network host \
         --env CLUSTER_DOMAIN="$CLUSTER_DOMAIN" \
+        --env CLUSTER_NAME="$CLUSTER_NAME" \
         "${COREDNS_IMAGE}" \
             --conf /etc/coredns/Corefile
 fi


### PR DESCRIPTION
We're using this for coredns on the masters, but we should also use
it on the bootstrap to avoid other environments polluting our DNS
entries.