### PR TITLE
Update bootkube output when waiting on DNS SRV.

### DIFF
--- a/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
+++ b/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
@@ -134,15 +134,14 @@ then
 	touch mco-bootstrap.done
 fi
 
-echo -n "Waiting for etcd member names to be available from SRV"
+echo "Waiting for etcd member names to be available from SRV ..."
 CLUSTER_DOMAIN="$(clusterinfo CLUSTER_DOMAIN)"
 while ! DNS_DISC_ANSWERS=$(host -t SRV "_etcd-server-ssl._tcp.$CLUSTER_DOMAIN"); do
-    echo -n "."
     sleep 1
 done
 
 ETCD_MEMBERS=$(awk '{print $NF}' <<< "$DNS_DISC_ANSWERS")
-echo " Found etcd members!"
+echo "Found etcd members!"
 
 function etcd-server-urls {
     local out


### PR DESCRIPTION
This log output doesn't actually show up in the log while we're in the
middle of waiting because of the lack of a newline.  Change this so if
you're following bootkube, you see this message as soon as we start
this section.