### PR TITLE
Use clusterinfo to get CLUSTER_DOMAIN

### DIFF
--- a/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
+++ b/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
@@ -135,7 +135,7 @@ then
 fi
 
 echo -n "Waiting for etcd member names to be available from SRV"
-CLUSTER_DOMAIN="$(awk '/search/ {print $2}' /etc/resolv.conf)"
+CLUSTER_DOMAIN="$(clusterinfo CLUSTER_DOMAIN)"
 while ! DNS_DISC_ANSWERS=$(host -t SRV "_etcd-server-ssl._tcp.$CLUSTER_DOMAIN"); do
     echo -n "."
     sleep 1

--- a/data/data/bootstrap/files/usr/local/bin/clusterinfo
+++ b/data/data/bootstrap/files/usr/local/bin/clusterinfo
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+CURRENT_CONTEXT=$(kubectl --kubeconfig /etc/kubernetes/kubeconfig config view -o jsonpath='{.current-context}')
+CLUSTER_NAME=$(kubectl --kubeconfig /etc/kubernetes/kubeconfig config view -o "jsonpath={.contexts[?(@.name == '""$CURRENT_CONTEXT""')].context.cluster}")
+APIURL=$(kubectl --kubeconfig /etc/kubernetes/kubeconfig config view -o "jsonpath={.clusters[?(@.name == '""$CLUSTER_NAME""')].cluster.server}")
+APIHOST=$(echo $APIURL | sed -e 's/.*\/\/\([^:]\+\).*/\1/g')
+CLUSTER_DOMAIN=${APIHOST#*.}
+BASE_DOMAIN=${CLUSTER_DOMAIN#*.}
+
+echo ${!1}


### PR DESCRIPTION
Relying on /etc/resolv.conf as source for cluster domain is less
resilient as there may be DHCP environments that have multiple clusters
and DHCP offering the search domain of one of them instead of the base
domain.