### PR TITLE
Lower SRV record limit to 2

### DIFF
--- a/data/data/bootstrap/files/etc/coredns/Corefile
+++ b/data/data/bootstrap/files/etc/coredns/Corefile
@@ -1,7 +1,7 @@
 . {
     errors
     health
-    mdns {$CLUSTER_DOMAIN} 3 {$CLUSTER_NAME}
+    mdns {$CLUSTER_DOMAIN} 2 {$CLUSTER_NAME}
     forward . /etc/coredns/resolv.conf
     cache 30
     reload


### PR DESCRIPTION
We added this to prevent individual etcd nodes from clustering with
only themselves, but etcd can cluster correctly with only 2 nodes.