### PR TITLE
Make bootstrap work on flexible dns entries

### DIFF
--- a/data/data/bootstrap/files/etc/coredns/Corefile
+++ b/data/data/bootstrap/files/etc/coredns/Corefile
@@ -1,7 +1,7 @@
 . {
     errors
     health
-    mdns {$CLUSTER_DOMAIN} 3 {$CLUSTER_NAME}
+    mdns {$CLUSTER_DOMAIN} {$NUM_DNS_MEMBERS} {$CLUSTER_NAME}
     forward . /etc/coredns/resolv.conf
     cache 30
     reload


### PR DESCRIPTION
Depending on having 1 or 3 masters, the number of dns entries
we need to wait for is different. We can check the number of masters
in cluster-config.yaml, and parameterize the pod on bootstrap,
to wait for the needed dns members.