### PR TITLE
Add a Dockerfile for building an installer binary image

### DIFF
--- a/images/baremetal/Dockerfile.ci
+++ b/images/baremetal/Dockerfile.ci
@@ -1,0 +1,24 @@
+# This Dockerfile is a used by CI to publish kni/origin-v4.0:installer
+# It builds an image containing only the openshift-install.
+
+FROM registry.svc.ci.openshift.org/openshift/release:golang-1.10 AS builder
+WORKDIR /go/src/github.com/openshift-metalkube/kni-installer
+COPY . .
+RUN TAGS="libvirt ironic" hack/build.sh
+
+
+FROM registry.svc.ci.openshift.org/openshift/origin-v4.0:base
+COPY --from=builder /go/src/github.com/openshift-metalkube/kni-installer/bin/kni-install /bin/openshift-install
+
+RUN yum install --setopt=tsflags=nodocs -y \
+    yum update -y && \
+    yum install --setopt=tsflags=nodocs -y \
+    libvirt-libs && \
+    yum clean all && rm -rf /var/cache/yum/*
+
+RUN mkdir /output && chown 1000:1000 /output
+USER 1000:1000
+ENV PATH /bin
+ENV HOME /output
+WORKDIR /output
+ENTRYPOINT ["/bin/openshift-install"]


### PR DESCRIPTION
This is just a variant of `images/installer/Dockerfile.ci` that builds an image with `kni-install` at `/usr/bin/openshift-instal`l - this is so `oc adm release extract --tools` knows how to extact it.

We also install libvirt-libs in the resulting image since the openshift-install binary is dynamically linked when using libvirt because it's built with`CGO_ENABLED=1` and there is no static libvirt library shipped in libvirt RPM builds.

Eventually, this dynamically linked binary will probably need to be published as a separate image (or perhaps in installer-artifacts) similarly to how the binary for mac is made available.

See also openshift-metalkube/dev-scripts#401