### PR TITLE
Work around extra host route.

### DIFF
--- a/data/data/bootstrap/files/etc/keepalived/keepalived.conf.tmpl
+++ b/data/data/bootstrap/files/etc/keepalived/keepalived.conf.tmpl
@@ -9,7 +9,7 @@ vrrp_instance ${CLUSTER_NAME}_API {
         auth_pass ${CLUSTER_NAME}_api_vip
     }
     virtual_ipaddress {
-        ${API_VIP}
+        ${API_VIP}/${NET_MASK}
     }
 }
 
@@ -24,6 +24,6 @@ vrrp_instance ${CLUSTER_NAME}_DNS {
         auth_pass ${CLUSTER_NAME}_dns_vip
     }
     virtual_ipaddress {
-        ${DNS_VIP}
+        ${DNS_VIP}/${NET_MASK}
     }
 }

--- a/data/data/bootstrap/files/usr/local/bin/keepalived.sh
+++ b/data/data/bootstrap/files/usr/local/bin/keepalived.sh
@@ -14,6 +14,7 @@ CLUSTER_NAME="$(awk -F. '{print $2}' <<< "$API_DNS")"
 API_VIP="$(dig +noall +answer "$API_DNS" | awk '{print $NF}')"
 IFACE_CIDRS="$(ip addr show | grep -v "scope host" | grep -Po 'inet \K[\d.]+/[\d.]+' | xargs)"
 SUBNET_CIDR="$(/usr/local/bin/get_vip_subnet_cidr "$API_VIP" "$IFACE_CIDRS")"
+NET_MASK="$(echo $SUBNET_CIDR | cut -d "/" -f 2)"
 INTERFACE="$(ip -o addr show to "$SUBNET_CIDR" | head -n 1 | awk '{print $2}')"
 CLUSTER_DOMAIN="${API_DNS#*.}"
 DNS_VIP="$(dig +noall +answer "ns1.${CLUSTER_DOMAIN}" | awk '{print $NF}')"
@@ -28,6 +29,7 @@ export INTERFACE
 export DNS_VIP
 export API_VRID
 export DNS_VRID
+export NET_MASK
 envsubst < /etc/keepalived/keepalived.conf.tmpl | sudo tee /etc/keepalived/keepalived.conf
 
 MATCHES="$(sudo podman ps -a --format "{{.Names}}" | awk '/keepalived$/ {print $0}')"


### PR DESCRIPTION
This is the kni-installer version of the following commit:
https://github.com/openshift-metalkube/dev-scripts/commit/21cb51d7e2476824c8571fc73ebbdb003bd8df19

The dev-scripts commit fixed the issue for masters, but the issue can
still occur on the bootstrap VM, breaking the deployment process.

The issue is that there's a /32 route someimtes not getting deleted
when the VIP moves to another node.  This changes the keepalived
config such that the route created matches another route that is still
correct for the host.