### PR TITLE
Revert "Lower SRV record limit to 2"

### DIFF
--- a/data/data/bootstrap/files/etc/coredns/Corefile
+++ b/data/data/bootstrap/files/etc/coredns/Corefile
@@ -1,7 +1,7 @@
 . {
     errors
     health
-    mdns {$CLUSTER_DOMAIN} 2 {$CLUSTER_NAME}
+    mdns {$CLUSTER_DOMAIN} 3 {$CLUSTER_NAME}
     forward . /etc/coredns/resolv.conf
     cache 30
     reload


### PR DESCRIPTION
This reverts commit b4351ad2c957c22343ad35c98244b7b01c94055b.

On bootstrap, we do not want to continue until we have all 3 nodes
available. Otherwise etcd will initially cluster with only 2 and
things get complicated. Since the DNS VIP moves off the bootstrap
once bootstrapping is complete, we should be okay to insist on 3
nodes here, but continue to allow 2 on the master coredns so that
the cluster remains operational if a node goes down.