### PR TITLE
bootstrap to be dns vip master until the end

### DIFF
--- a/data/data/bootstrap/files/etc/keepalived/keepalived.conf.tmpl
+++ b/data/data/bootstrap/files/etc/keepalived/keepalived.conf.tmpl
@@ -14,10 +14,10 @@ vrrp_instance ${CLUSTER_NAME}_API {
 }
 
 vrrp_instance ${CLUSTER_NAME}_DNS {
-    state BACKUP
+    state MASTER
     interface ${INTERFACE}
     virtual_router_id ${DNS_VRID}
-    priority 50
+    priority 140
     advert_int 1
     authentication {
         auth_type PASS


### PR DESCRIPTION
The reason for this is that during bootstrapping, and only during
bootstrapping we want to enforce that unless TOTAL_AMOUNT_OF_MASTERS is
available for the Etcd SRV record, we give out NXDOMAIN answer for the
SRV query that Etcd uses to cluster.

Signed-off-by: Antoni Segura Puimedon <antoni@redhat.com>