### PR TITLE
Add api-int record to bootstrap

### DIFF
--- a/data/data/bootstrap/files/etc/coredns/Corefile
+++ b/data/data/bootstrap/files/etc/coredns/Corefile
@@ -5,4 +5,7 @@
     forward . /etc/coredns/resolv.conf
     cache 30
     reload
+    hosts /etc/coredns/api-int.hosts {$CLUSTER_DOMAIN} {
+        fallthrough
+    }
 }

--- a/data/data/bootstrap/files/etc/coredns/api-int.hosts.env
+++ b/data/data/bootstrap/files/etc/coredns/api-int.hosts.env
@@ -1,0 +1,1 @@
+${API_VIP} api-int.${CLUSTER_DOMAIN}

--- a/data/data/bootstrap/files/usr/local/bin/coredns.sh
+++ b/data/data/bootstrap/files/usr/local/bin/coredns.sh
@@ -14,6 +14,8 @@ SUBNET_CIDR="$(/usr/local/bin/get_vip_subnet_cidr "$API_VIP" "$IFACE_CIDRS")"
 DNS_VIP="$(dig +noall +answer "ns1.${CLUSTER_DOMAIN}" | awk '{print $NF}')"
 grep -Ev "${DNS_VIP}|127.0.0.1" /etc/resolv.conf | tee /etc/coredns/resolv.conf
 NUM_DNS_MEMBERS=$(grep -A 5 'controlPlane' /opt/openshift/manifests/cluster-config.yaml | awk '/replicas/ {print $2}')
+export API_VIP CLUSTER_DOMAIN
+envsubst < /etc/coredns/api-int.hosts.env > /etc/coredns/api-int.hosts
 
 COREDNS_IMAGE="quay.io/openshift-metalkube/coredns-mdns:latest"
 if ! podman inspect "$COREDNS_IMAGE" &>/dev/null; then


### PR DESCRIPTION
Add the hosts plugin to coredns so that we can create a static entry
for api-int.$CLUSTER_DOMAIN. hosts is used because it doesn't have to
be authoritative for the zone and can allow fallthrough of records
that are not found.