### PR TITLE
Change name of Machine labels.

### DIFF
--- a/pkg/asset/machines/baremetal/machines.go
+++ b/pkg/asset/machines/baremetal/machines.go
@@ -42,9 +42,9 @@ func Machines(clusterID string, config *types.InstallConfig, pool *types.Machine
 				Namespace: "openshift-machine-api",
 				Name:      fmt.Sprintf("%s-%s-%d", clustername, pool.Name, idx),
 				Labels: map[string]string{
-					"sigs.k8s.io/cluster-api-cluster":      clustername,
-					"sigs.k8s.io/cluster-api-machine-role": role,
-					"sigs.k8s.io/cluster-api-machine-type": role,
+					"machine.openshift.io/cluster-api-cluster":      clustername,
+					"machine.openshift.io/cluster-api-machine-role": role,
+					"machine.openshift.io/cluster-api-machine-type": role,
 				},
 			},
 			Spec: machineapi.MachineSpec{

--- a/pkg/asset/machines/baremetal/machinesets.go
+++ b/pkg/asset/machines/baremetal/machinesets.go
@@ -43,26 +43,26 @@ func MachineSets(clusterID string, config *types.InstallConfig, pool *types.Mach
 			Namespace: "openshift-machine-api",
 			Name:      name,
 			Labels: map[string]string{
-				"sigs.k8s.io/cluster-api-cluster":      clustername,
-				"sigs.k8s.io/cluster-api-machine-role": role,
-				"sigs.k8s.io/cluster-api-machine-type": role,
+				"machine.openshift.io/cluster-api-cluster":      clustername,
+				"machine.openshift.io/cluster-api-machine-role": role,
+				"machine.openshift.io/cluster-api-machine-type": role,
 			},
 		},
 		Spec: machineapi.MachineSetSpec{
 			Replicas: pointer.Int32Ptr(int32(total)),
 			Selector: metav1.LabelSelector{
 				MatchLabels: map[string]string{
-					"sigs.k8s.io/cluster-api-machineset": name,
-					"sigs.k8s.io/cluster-api-cluster":    clustername,
+					"machine.openshift.io/cluster-api-machineset": name,
+					"machine.openshift.io/cluster-api-cluster":    clustername,
 				},
 			},
 			Template: machineapi.MachineTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
-						"sigs.k8s.io/cluster-api-machineset":   name,
-						"sigs.k8s.io/cluster-api-cluster":      clustername,
-						"sigs.k8s.io/cluster-api-machine-role": role,
-						"sigs.k8s.io/cluster-api-machine-type": role,
+						"machine.openshift.io/cluster-api-machineset":   name,
+						"machine.openshift.io/cluster-api-cluster":      clustername,
+						"machine.openshift.io/cluster-api-machine-role": role,
+						"machine.openshift.io/cluster-api-machine-type": role,
 					},
 				},
 				Spec: machineapi.MachineSpec{


### PR DESCRIPTION
    openshift/installer changed the Machine label names in commit
    be7bf8ec27c7c91be43eac41346da1730c6e3d31.  The newest
    openshift/cluster-api code validates Machine objects against this
    updated label as well, causing the failure seen here:
    
    https://github.com/openshift-metal3/dev-scripts/issues/537#issuecomment-493116626
