### PR TITLE
Point Ignition at API VIP directly

### DIFF
--- a/data/data/bootstrap/files/etc/coredns/Corefile
+++ b/data/data/bootstrap/files/etc/coredns/Corefile
@@ -6,6 +6,7 @@
     cache 30
     reload
     hosts /etc/coredns/api-int.hosts {$CLUSTER_DOMAIN} {
+        {$API_VIP} api-int.{$CLUSTER_DOMAIN}
         fallthrough
     }
 }

--- a/data/data/bootstrap/files/etc/coredns/api-int.hosts.env
+++ b/data/data/bootstrap/files/etc/coredns/api-int.hosts.env
@@ -1,1 +1,0 @@
-${API_VIP} api-int.${CLUSTER_DOMAIN}

--- a/data/data/bootstrap/files/usr/local/bin/coredns.sh
+++ b/data/data/bootstrap/files/usr/local/bin/coredns.sh
@@ -15,7 +15,6 @@ DNS_VIP="$(dig +noall +answer "ns1.${CLUSTER_DOMAIN}" | awk '{print $NF}')"
 grep -Ev "${DNS_VIP}|127.0.0.1" /etc/resolv.conf | tee /etc/coredns/resolv.conf
 NUM_DNS_MEMBERS=$(grep -A 5 'controlPlane' /opt/openshift/manifests/cluster-config.yaml | awk '/replicas/ {print $2}')
 export API_VIP CLUSTER_DOMAIN
-envsubst < /etc/coredns/api-int.hosts.env > /etc/coredns/api-int.hosts
 
 COREDNS_IMAGE="quay.io/openshift-metalkube/coredns-mdns:latest"
 if ! podman inspect "$COREDNS_IMAGE" &>/dev/null; then
@@ -31,6 +30,7 @@ if [[ -z "$MATCHES" ]]; then
         --env CLUSTER_DOMAIN="$CLUSTER_DOMAIN" \
         --env CLUSTER_NAME="$CLUSTER_NAME" \
         --env NUM_DNS_MEMBERS="$NUM_DNS_MEMBERS" \
+        --env API_VIP="$API_VIP" \
         "${COREDNS_IMAGE}" \
             --conf /etc/coredns/Corefile
 fi

--- a/pkg/asset/cluster/baremetal/baremetal.go
+++ b/pkg/asset/cluster/baremetal/baremetal.go
@@ -12,5 +12,6 @@ func Metadata(infraID string, config *types.InstallConfig) *baremetal.Metadata {
 	return &baremetal.Metadata{
 		LibvirtURI: config.Platform.BareMetal.LibvirtURI,
 		IronicURI: config.Platform.BareMetal.IronicURI,
+		ApiVIP: config.Platform.BareMetal.ApiVIP,
 	}
 }

--- a/pkg/asset/ignition/machine/node.go
+++ b/pkg/asset/ignition/machine/node.go
@@ -13,6 +13,12 @@ import (
 // pointerIgnitionConfig generates a config which references the remote config
 // served by the machine config server.
 func pointerIgnitionConfig(installConfig *types.InstallConfig, rootCA []byte, role string) *ignition.Config {
+	ignitionHost := fmt.Sprintf("api-int.%s:22623", installConfig.ClusterDomain())
+	if installConfig.Platform.BareMetal != nil {
+		// Baremetal needs to point directly at the VIP because we don't have a
+		// way to configure DNS before Ignition runs.
+		ignitionHost = fmt.Sprintf("%s:22623", installConfig.BareMetal.ApiVIP)
+	}
 	return &ignition.Config{
 		Ignition: ignition.Ignition{
 			Version: ignition.MaxVersion.String(),
@@ -21,7 +27,7 @@ func pointerIgnitionConfig(installConfig *types.InstallConfig, rootCA []byte, ro
 					Source: func() *url.URL {
 						return &url.URL{
 							Scheme: "https",
-							Host:   fmt.Sprintf("api-int.%s:22623", installConfig.ClusterDomain()),
+							Host:   ignitionHost,
 							Path:   fmt.Sprintf("/config/%s", role),
 						}
 					}().String(),

--- a/pkg/asset/installconfig/baremetal/baremetal.go
+++ b/pkg/asset/installconfig/baremetal/baremetal.go
@@ -12,7 +12,7 @@ import (
 
 // Platform collects bare metal specific configuration.
 func Platform() (*baremetal.Platform, error) {
-	var libvirtURI, ironicURI, nodesJSON string
+	var libvirtURI, ironicURI, nodesJSON, apiVIP string
 	err := survey.Ask([]*survey.Question{
 		{
 			Prompt: &survey.Input{
@@ -58,10 +58,24 @@ func Platform() (*baremetal.Platform, error) {
 		return nil, err
 	}
 
+	err = survey.Ask([]*survey.Question{
+		{
+			Prompt: &survey.Input{
+				Message: "API VIP",
+				Help:    "The VIP to be used for internal API communication.",
+			},
+			Validate: survey.ComposeValidators(survey.Required, ipValidator),
+		},
+	}, &apiVIP)
+	if err != nil {
+		return nil, err
+	}
+
 	return &baremetal.Platform{
 		LibvirtURI: libvirtURI,
 		IronicURI: ironicURI,
 		Nodes: nodes,
+		ApiVIP: apiVIP,
 	}, nil
 }
 
@@ -69,4 +83,8 @@ func Platform() (*baremetal.Platform, error) {
 // url and has non-empty scheme.
 func uriValidator(ans interface{}) error {
 	return validate.URI(ans.(string))
+}
+
+func ipValidator(ans interface{}) error {
+	return validate.IP(ans.(string))
 }

--- a/pkg/asset/tls/mcscertkey.go
+++ b/pkg/asset/tls/mcscertkey.go
@@ -3,6 +3,7 @@ package tls
 import (
 	"crypto/x509"
 	"crypto/x509/pkix"
+	"net"
 
 	"github.com/openshift-metalkube/kni-installer/pkg/asset"
 	"github.com/openshift-metalkube/kni-installer/pkg/asset/installconfig"
@@ -35,9 +36,10 @@ func (a *MCSCertKey) Generate(dependencies asset.Parents) error {
 
 	cfg := &CertCfg{
 		Subject:      pkix.Name{CommonName: hostname},
+		IPAddresses:  []net.IP{net.ParseIP(installConfig.Config.BareMetal.ApiVIP)},
 		ExtKeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
 		Validity:     ValidityTenYears,
-		DNSNames:     []string{hostname},
+		DNSNames:     []string{hostname, installConfig.Config.BareMetal.ApiVIP},
 	}
 
 	return a.SignedCertKey.Generate(cfg, ca, "machine-config-server", DoNotAppendParent)

--- a/pkg/types/baremetal/metadata.go
+++ b/pkg/types/baremetal/metadata.go
@@ -4,4 +4,5 @@ package baremetal
 type Metadata struct {
 	LibvirtURI string `json:"libvirt_uri"`
 	IronicURI  string `json:"ironic_uri"`
+	ApiVIP     string `json:"api_vip"`
 }

--- a/pkg/types/baremetal/platform.go
+++ b/pkg/types/baremetal/platform.go
@@ -27,4 +27,7 @@ type Platform struct {
 	// platform configuration.
 	// +optional
 	DefaultMachinePlatform *MachinePool `json:"defaultMachinePlatform,omitempty"`
+
+	// ApiVIP is the VIP to use for internal API communication
+	ApiVIP string `json:"api_vip"`
 }

--- a/pkg/validate/validate.go
+++ b/pkg/validate/validate.go
@@ -113,3 +113,12 @@ func URI(uri string) error {
 	}
 	return nil
 }
+
+// IP validates if a string is a valid IP.
+func IP(ip string) error {
+	addr := net.ParseIP(ip)
+	if addr == nil {
+		return fmt.Errorf("%s is not a valid IP", ip)
+	}
+	return nil
+}


### PR DESCRIPTION
Instead of having Ignition use the DNS name for the API, which will
be problematic in 4.1 where it switches to api-int, get the VIP from
the configuration and use that directly.