### PR TITLE
Provide BareMetalMachineProviderSpec with the right fields

### DIFF
--- a/pkg/asset/machines/baremetal/machines.go
+++ b/pkg/asset/machines/baremetal/machines.go
@@ -9,6 +9,7 @@ import (
 	machineapi "github.com/openshift/cluster-api/pkg/apis/machine/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+        corev1 "k8s.io/api/core/v1"
 
 	"github.com/openshift-metalkube/kni-installer/pkg/types"
 	"github.com/openshift-metalkube/kni-installer/pkg/types/baremetal"
@@ -60,5 +61,11 @@ func Machines(clusterID string, config *types.InstallConfig, pool *types.Machine
 }
 
 func provider(clusterName string, networkInterfaceAddress string, platform *baremetal.Platform, userDataSecret string) *baremetalprovider.BareMetalMachineProviderSpec {
-	return &baremetalprovider.BareMetalMachineProviderSpec{}
+	return &baremetalprovider.BareMetalMachineProviderSpec{
+                Image: baremetalprovider.Image{
+                        URL: platform.MasterConfiguration["image_source"].(string),
+                        Checksum: platform.MasterConfiguration["image_checksum"].(string),
+                },
+                UserData: &corev1.SecretReference{Name: userDataSecret},
+        }
 }


### PR DESCRIPTION
Fixes #87 

kni-install will create the master Machines and worker MachineSet
with the baremetal machine providerSpec. cluster-api-provider-baremetal
expects two fields: the image and userdata (checksum URL).
After this change the cluster-api-provider baremetal can now start
using this image provided via the BareMetalMachineProviderSpec instead
of a hard-coded one.