### PR TITLE
Refactor install-config

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -451,6 +451,17 @@
 
 [[projects]]
   branch = "master"
+  digest = "1:eeb4dc1fe5163871428f9049ecdfbae752b9bec868ed4558d168e109a2f3a4e6"
+  name = "github.com/metal3-io/baremetal-operator"
+  packages = [
+    "pkg/bmc",
+    "pkg/hardware",
+  ]
+  pruneopts = "NUT"
+  revision = "cbdbe42e35bf58687ff7442271fedbc2ac5f1c5b"
+
+[[projects]]
+  branch = "master"
   digest = "1:f6eb318ba8e4077e55d4eb85732da14166d0948df8ee3bbee40c7f5f75f9127f"
   name = "github.com/metal3-io/cluster-api-provider-baremetal"
   packages = [
@@ -1228,7 +1239,10 @@
     "github.com/gophercloud/gophercloud/openstack/objectstorage/v1/objects",
     "github.com/gophercloud/utils/openstack/clientconfig",
     "github.com/libvirt/libvirt-go",
+    "github.com/metal3-io/baremetal-operator/pkg/bmc",
+    "github.com/metal3-io/baremetal-operator/pkg/hardware",
     "github.com/metal3-io/cluster-api-provider-baremetal/pkg/apis",
+    "github.com/metal3-io/cluster-api-provider-baremetal/pkg/apis/baremetal/v1alpha1",
     "github.com/openshift/api/config/v1",
     "github.com/openshift/client-go/config/clientset/versioned",
     "github.com/openshift/client-go/route/clientset/versioned",
@@ -1237,10 +1251,14 @@
     "github.com/openshift/cluster-api-provider-libvirt/pkg/apis",
     "github.com/openshift/cluster-api-provider-libvirt/pkg/apis/libvirtproviderconfig/v1beta1",
     "github.com/openshift/cluster-api/pkg/apis/machine/v1beta1",
+    "github.com/openshift/installer/pkg/asset/installconfig/aws",
+    "github.com/openshift/installer/pkg/types/aws/defaults",
+    "github.com/openshift/installer/pkg/types/aws/validation",
     "github.com/openshift/library-go/pkg/config/clusteroperator/v1helpers",
     "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1",
     "github.com/pborman/uuid",
     "github.com/pkg/errors",
+    "github.com/rodaine/hclencoder",
     "github.com/shurcooL/vfsgen",
     "github.com/sirupsen/logrus",
     "github.com/spf13/cobra",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -108,3 +108,7 @@ required = [
   branch = "master"
   name = "github.com/metal3-io/cluster-api-provider-baremetal"
   source = "github.com/openshift/cluster-api-provider-baremetal/pkg/apis"
+
+[[constraint]]
+  branch = "master"
+  name = "github.com/metal3-io/baremetal-operator"

--- a/data/data/baremetal/main.tf
+++ b/data/data/baremetal/main.tf
@@ -20,14 +20,13 @@ module "bootstrap" {
 module "masters" {
   source = "./masters"
 
-  ignition       = var.ignition_master
-  image_source   = var.master_configuration["image_source"]
-  image_checksum = var.master_configuration["image_checksum"]
-  root_gb        = var.master_configuration["root_gb"]
+  master_count = var.master_count
+  ignition     = var.ignition_master
 
-  master_nodes = var.master_nodes
-  properties   = var.properties
-  root_devices = var.root_devices
-  driver_infos = var.driver_infos
+  hosts          = var.hosts
+  properties     = var.properties
+  root_devices   = var.root_devices
+  driver_infos   = var.driver_infos
+  instance_infos = var.instance_infos
 }
 

--- a/data/data/baremetal/masters/variables.tf
+++ b/data/data/baremetal/masters/variables.tf
@@ -1,40 +1,35 @@
-variable "image_source" {
-  description = "The URL of the OS disk image"
+variable "master_count" {
   type        = string
+  description = "Number of masters"
+  default     = 3
 }
-
-variable "image_checksum" {
-  type        = string
-  description = "The URL or checksum value of the image"
-}
-
-variable "root_gb" {
-  type        = string
-  description = "Size of the root disk"
-}
-
 variable "ignition" {
   type        = string
   description = "The content of the master ignition file"
 }
 
-variable "master_nodes" {
-  type        = map(map(string))
-  description = "Master bare metal node details"
+variable "hosts" {
+  type        = list(map(string))
+  description = "Hardware details for hosts"
 }
 
 variable "properties" {
-  type        = map(map(string))
-  description = "Master bare metal properties"
+  type        = list(map(string))
+  description = "Properties for hosts"
 }
 
 variable "root_devices" {
-  type        = map(map(string))
-  description = "Master root device configuration"
+  type        = list(map(string))
+  description = "Root devices for hosts"
 }
 
 variable "driver_infos" {
-  type        = map(map(string))
-  description = "Master driver info"
+  type        = list(map(string))
+  description = "BMC information for hosts"
+}
+
+variable "instance_infos" {
+  type        = list(map(string))
+  description = "Instance information for hosts"
 }
 

--- a/data/data/baremetal/variables-baremetal.tf
+++ b/data/data/baremetal/variables-baremetal.tf
@@ -23,28 +23,28 @@ variable "provisioning_bridge" {
   description = "The name of the provisioning bridge"
 }
 
-variable "master_configuration" {
-  type        = map(string)
-  description = "Configuration information for masters such as image location"
-}
-
-variable "master_nodes" {
-  type        = map(map(string))
-  description = "Master bare metal node details"
+variable "hosts" {
+  type        = list(map(string))
+  description = "Hardware details for hosts"
 }
 
 variable "properties" {
-  type        = map(map(string))
-  description = "Master bare metal properties"
+  type        = list(map(string))
+  description = "Properties for hosts"
 }
 
 variable "root_devices" {
-  type        = map(map(string))
-  description = "Master root device configurations"
+  type        = list(map(string))
+  description = "Root devices for hosts"
 }
 
 variable "driver_infos" {
-  type        = map(map(string))
-  description = "Master driver infos"
+  type        = list(map(string))
+  description = "BMC information for hosts"
+}
+
+variable "instance_infos" {
+  type        = list(map(string))
+  description = "Instance information for hosts"
 }
 

--- a/pkg/asset/cluster/tfvars.go
+++ b/pkg/asset/cluster/tfvars.go
@@ -211,15 +211,14 @@ func (t *TerraformVariables) Generate(parents asset.Parents) error {
 			Data:     data,
 		})
 	case baremetal.Name:
-		// FIXME:: baremetal
 		data, err = baremetaltfvars.TFVars(
 			installConfig.Config.Platform.BareMetal.LibvirtURI,
 			installConfig.Config.Platform.BareMetal.IronicURI,
 			string(*rhcosImage),
 			"baremetal",
 			"provisioning",
-			installConfig.Config.Platform.BareMetal.Nodes,
-			installConfig.Config.Platform.BareMetal.MasterConfiguration,
+			installConfig.Config.Platform.BareMetal.Hosts,
+			installConfig.Config.Platform.BareMetal.Image,
 			)
 		if err != nil {
 			return errors.Wrapf(err, "failed to get %s Terraform variables", platform)

--- a/pkg/asset/installconfig/baremetal/host.go
+++ b/pkg/asset/installconfig/baremetal/host.go
@@ -1,0 +1,87 @@
+package baremetal
+
+import (
+	"github.com/openshift-metalkube/kni-installer/pkg/types/baremetal"
+	"gopkg.in/AlecAivazis/survey.v1"
+)
+
+func Host() (*baremetal.Host, error) {
+	var host baremetal.Host
+
+	err := survey.Ask([]*survey.Question{
+		{
+			Prompt: &survey.Input{
+				Message: "Name",
+			},
+			Validate: survey.ComposeValidators(survey.Required),
+		},
+	}, &host.Name)
+	if err != nil {
+		return nil, err
+	}
+
+	err = survey.Ask([]*survey.Question{
+		{
+			Prompt: &survey.Input{
+				Message: "BMC Address",
+				Help:    "The address for the BMC, e.g. ipmi://192.168.0.1",
+			},
+			Validate: survey.ComposeValidators(survey.Required, uriValidator),
+		},
+	}, &host.BMC.Address)
+	if err != nil {
+		return nil, err
+	}
+
+	err = survey.Ask([]*survey.Question{
+		{
+			Prompt: &survey.Input{
+				Message: "BMC Username",
+			},
+			Validate: survey.ComposeValidators(survey.Required),
+		},
+	}, &host.BMC.Username)
+	if err != nil {
+		return nil, err
+	}
+
+	err = survey.Ask([]*survey.Question{
+		{
+			Prompt: &survey.Password{
+				Message: "BMC Password",
+			},
+			Validate: survey.ComposeValidators(survey.Required),
+		},
+	}, &host.BMC.Password)
+	if err != nil {
+		return nil, err
+	}
+
+	err = survey.Ask([]*survey.Question{
+		{
+			Prompt: &survey.Input{
+				Message: "Boot MAC Address",
+			},
+			Validate: survey.ComposeValidators(survey.Required, macValidator),
+		},
+	}, &host.BootMACAddress)
+	if err != nil {
+		return nil, err
+	}
+
+	err = survey.Ask([]*survey.Question{
+		{
+			Prompt: &survey.Select{
+				Message: "Hardware profile",
+				Options: []string{"default", "libvirt", "dell", "dell-raid"},
+				Default: "default",
+			},
+		},
+	}, &host.HardwareProfile)
+	if err != nil {
+		return nil, err
+	}
+
+
+	return &host, nil
+}

--- a/pkg/asset/machines/baremetal/machines.go
+++ b/pkg/asset/machines/baremetal/machines.go
@@ -63,8 +63,8 @@ func Machines(clusterID string, config *types.InstallConfig, pool *types.Machine
 func provider(clusterName string, networkInterfaceAddress string, platform *baremetal.Platform, userDataSecret string) *baremetalprovider.BareMetalMachineProviderSpec {
 	return &baremetalprovider.BareMetalMachineProviderSpec{
                 Image: baremetalprovider.Image{
-                        URL: platform.MasterConfiguration["image_source"].(string),
-                        Checksum: platform.MasterConfiguration["image_checksum"].(string),
+                        URL: platform.Image.Source,
+                        Checksum: platform.Image.Checksum,
                 },
                 UserData: &corev1.SecretReference{Name: userDataSecret},
         }

--- a/pkg/asset/manifests/infrastructure.go
+++ b/pkg/asset/manifests/infrastructure.go
@@ -69,7 +69,7 @@ func (i *Infrastructure) Generate(dependencies asset.Parents) error {
 	case azure.Name:
 		platform = configv1.AzurePlatformType
 	case baremetal.Name:
-		platform = configv1.BareMetalPlatform
+		platform = configv1.BareMetalPlatformType
 	default:
 		platform = configv1.NonePlatformType
 	}

--- a/pkg/tfvars/baremetal/baremetal.go
+++ b/pkg/tfvars/baremetal/baremetal.go
@@ -3,7 +3,10 @@ package baremetal
 
 import (
 	"encoding/json"
+	"github.com/metal3-io/baremetal-operator/pkg/bmc"
+	"github.com/metal3-io/baremetal-operator/pkg/hardware"
 	libvirttfvars "github.com/openshift-metalkube/kni-installer/pkg/tfvars/libvirt"
+	"github.com/openshift-metalkube/kni-installer/pkg/types/baremetal"
 	"github.com/pkg/errors"
 )
 
@@ -14,34 +17,90 @@ type config struct {
 	ExternalBridge     string `json:"external_bridge,omitempty"`
 	ProvisioningBridge string `json:"provisioning_bridge,omitempty"`
 
-	// Data required for masters deployment - several maps per master, because of terraform's
-	// limitation that maps cannot be strings
-	MasterNodes interface{} `json:"master_nodes"`
-	Properties  interface{} `json:"properties"`
-	RootDevices interface{} `json:"root_devices"`
-	DriverInfos interface{} `json:"driver_infos"`
-
-	MasterConfiguration map[string]interface{} `json:"master_configuration"`
+	// Data required for control plane deployment - several maps per host, because of terraform's limitations
+	Hosts         []map[string]interface{} `json:"hosts"`
+	RootDevices   []map[string]interface{} `json:"root_devices"`
+	Properties    []map[string]interface{} `json:"properties"`
+	DriverInfos   []map[string]interface{} `json:"driver_infos"`
+	InstanceInfos []map[string]interface{} `json:"instance_infos"`
 }
 
 // TFVars generates bare metal specific Terraform variables.
-func TFVars(libvirtURI, ironicURI, osImage, externalBridge, provisioningBridge string, nodes map[string]interface{}, configuration map[string]interface{}) ([]byte, error) {
+func TFVars(libvirtURI, ironicURI, osImage, externalBridge, provisioningBridge string, platformHosts []*baremetal.Host, image baremetal.Image) ([]byte, error) {
 	osImage, err := libvirttfvars.CachedImage(osImage)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to use cached libvirt image")
 	}
 
+	var hosts, rootDevices, properties, driverInfos, instanceInfos []map[string]interface{}
+
+	for _, host := range platformHosts {
+		// Get hardware profile
+		if host.HardwareProfile == "default" {
+			host.HardwareProfile = hardware.DefaultProfileName
+		}
+
+		profile, err := hardware.GetProfile(host.HardwareProfile)
+		if err != nil {
+			return nil, err
+		}
+
+		// BMC Driver Info
+		accessDetails, _ := bmc.NewAccessDetails(host.BMC.Address)
+		credentials := bmc.Credentials{
+			Username: host.BMC.Username,
+			Password: host.BMC.Password,
+		}
+		driverInfo := accessDetails.DriverInfo(credentials)
+		driverInfo["deploy_kernel"] = image.DeployKernel
+		driverInfo["deploy_ramdisk"] = image.DeployRamdisk
+
+		// Host Details
+		hostMap := map[string]interface{}{
+			"name":         host.Name,
+			"port_address": host.BootMACAddress,
+			"driver":       accessDetails.Type(),
+		}
+
+		// Properties
+		propertiesMap := map[string]interface{}{
+			"local_gb": profile.LocalGB,
+			"cpu_arch": profile.CPUArch,
+		}
+
+		// Root device hints
+		rootDevice := make(map[string]interface{})
+		if profile.RootDeviceHints.HCTL != "" {
+			rootDevice["hctl"] = profile.RootDeviceHints.HCTL
+		} else {
+			rootDevice["name"] = profile.RootDeviceHints.DeviceName
+		}
+
+		// Instance Info
+		instanceInfo := map[string]interface{}{
+			"root_gb":        25, // FIXME(stbenjam): Needed until https://storyboard.openstack.org/#!/story/2005165
+			"image_source":   image.Source,
+			"image_checksum": image.Checksum,
+		}
+
+		hosts = append(hosts, hostMap)
+		properties = append(properties, propertiesMap)
+		driverInfos = append(driverInfos, driverInfo)
+		rootDevices = append(rootDevices, rootDevice)
+		instanceInfos = append(instanceInfos, instanceInfo)
+	}
+
 	cfg := &config{
-		LibvirtURI:          libvirtURI,
-		IronicURI:           ironicURI,
-		Image:               osImage,
-		ExternalBridge:      externalBridge,
-		ProvisioningBridge:  provisioningBridge,
-		MasterNodes:         nodes["master_nodes"],
-		Properties:          nodes["properties"],
-		RootDevices:         nodes["root_devices"],
-		DriverInfos:         nodes["driver_infos"],
-		MasterConfiguration: configuration,
+		LibvirtURI:         libvirtURI,
+		IronicURI:          ironicURI,
+		Image:              osImage,
+		ExternalBridge:     externalBridge,
+		ProvisioningBridge: provisioningBridge,
+		Hosts:              hosts,
+		Properties:         properties,
+		DriverInfos:        driverInfos,
+		RootDevices:        rootDevices,
+		InstanceInfos:      instanceInfos,
 	}
 
 	return json.MarshalIndent(cfg, "", "  ")

--- a/pkg/types/baremetal/defaults/platform.go
+++ b/pkg/types/baremetal/defaults/platform.go
@@ -9,6 +9,7 @@ const (
 	IronicURI          = "http://localhost:6385/v1"
 	ExternalBridge     = "baremetal"
 	ProvisioningBridge = "provisioning"
+	HardwareProfile    = "default"
 )
 
 // SetPlatformDefaults sets the defaults for the platform.
@@ -27,5 +28,11 @@ func SetPlatformDefaults(p *baremetal.Platform) {
 
 	if p.ProvisioningBridge == "" {
 		p.ProvisioningBridge = ProvisioningBridge
+	}
+
+	for _, host := range p.Hosts {
+		if host.HardwareProfile == "" {
+			host.HardwareProfile = HardwareProfile
+		}
 	}
 }

--- a/pkg/types/baremetal/platform.go
+++ b/pkg/types/baremetal/platform.go
@@ -1,7 +1,27 @@
 package baremetal
 
-// Platform stores all the global configuration that all
-// machinesets use.
+type BMC struct {
+	Username string `json:"username"`
+	Password string `json:"password"`
+	Address  string `json":"address"`
+}
+
+type Host struct {
+	Name            string `json:"name,omitempty"`
+	BMC             BMC    `json:"bmc"`
+	Role            string `json:"role"`
+	BootMACAddress  string `json:"bootMACAddress"`
+	HardwareProfile string `json:"hardwareProfile"`
+}
+
+type Image struct {
+	Source        string `json:"source"`
+	Checksum      string `json:"checksum"`
+	DeployKernel  string `json:"deployKernel"`
+	DeployRamdisk string `json:"deployRamdisk"`
+}
+
+// Platform stores all the global configuration that all machinesets use.
 type Platform struct {
 	// LibvirtURI is the identifier for the libvirtd connection.  It must be
 	// reachable from the host where the installer is run.
@@ -22,13 +42,11 @@ type Platform struct {
 	// +optional
 	ProvisioningBridge string `json:"provisioning_bridge,omitempty"`
 
-	// Nodes is the information needed to create the master nodes in
-	// Ironic.
-	Nodes map[string]interface{} `json:"nodes"`
+	// Hosts is the information needed to create the objects in Ironic.
+	Hosts []*Host `json:"hosts"`
 
-	// MasterConfiguration contains the information needed to provision
-	// a master.
-	MasterConfiguration map[string]interface{} `json:"master_configuration"`
+	// Images contains the information needed to provision a host
+	Image Image `json:"image"`
 
 	// DefaultMachinePlatform is the default configuration used when
 	// installing on bare metal for machine pools which do not define their own

--- a/pkg/types/baremetal/validation/platform.go
+++ b/pkg/types/baremetal/validation/platform.go
@@ -25,8 +25,8 @@ func ValidatePlatform(p *baremetal.Platform, fldPath *field.Path) field.ErrorLis
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("provisioning_bridge"), p.ProvisioningBridge, err.Error()))
 	}
 
-	if p.Nodes == nil {
-		allErrs = append(allErrs, field.Invalid(fldPath.Child("nodes"), p.Nodes, "nodes is missing"))
+	if p.Hosts == nil {
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("nodes"), p.Hosts, "bare metal hosts are missing"))
 	}
 
 	if p.DefaultMachinePlatform != nil {

--- a/pkg/validate/validate.go
+++ b/pkg/validate/validate.go
@@ -130,3 +130,9 @@ func Interface(iface string) error {
 	}
 	return nil
 }
+
+// Validates that a value is a valid mac address
+func MAC(addr string) error {
+	_, err := net.ParseMAC(addr)
+	return err
+}

--- a/vendor/github.com/metal3-io/baremetal-operator/LICENSE
+++ b/vendor/github.com/metal3-io/baremetal-operator/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/github.com/metal3-io/baremetal-operator/pkg/bmc/access.go
+++ b/vendor/github.com/metal3-io/baremetal-operator/pkg/bmc/access.go
@@ -1,0 +1,113 @@
+package bmc
+
+import (
+	"net"
+	"net/url"
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
+// AccessDetails contains the information about how to get to a BMC.
+//
+// NOTE(dhellmann): This structure is very likely to change as we
+// adapt it to additional types.
+type AccessDetails interface {
+	// Type returns the kind of the BMC, indicating the driver that
+	// will be used to communicate with it.
+	Type() string
+
+	// NeedsMAC returns true when the host is going to need a separate
+	// port created rather than having it discovered.
+	NeedsMAC() bool
+
+	// The name of the driver to instantiate the BMC with. This may differ
+	// from the Type - both the ipmi and libvirt types use the ipmi driver.
+	Driver() string
+
+	// DriverInfo returns a data structure to pass as the DriverInfo
+	// parameter when creating a node in Ironic. The structure is
+	// pre-populated with the access information, and the caller is
+	// expected to add any other information that might be needed
+	// (such as the kernel and ramdisk locations).
+	DriverInfo(bmcCreds Credentials) map[string]interface{}
+}
+
+func getTypeHostPort(address string) (bmcType, host, port, path string, err error) {
+	// Start by assuming "type://host:port"
+	parsedURL, err := url.Parse(address)
+	if err != nil {
+		// We failed to parse the URL, but it may just be a host or
+		// host:port string (which the URL parser rejects because ":"
+		// is not allowed in the first segment of a
+		// path. Unfortunately there is no error class to represent
+		// that specific error, so we have to guess.
+		if strings.Contains(address, ":") {
+			// If we can parse host:port, carry on with those
+			// values. Otherwise, report the original parser error.
+			var err2 error
+			host, port, err2 = net.SplitHostPort(address)
+			if err2 != nil {
+				return "", "", "", "", errors.Wrap(err, "failed to parse BMC address information")
+			}
+			bmcType = "ipmi"
+		} else {
+			bmcType = "ipmi"
+			host = address
+		}
+	} else {
+		// Successfully parsed the URL
+		bmcType = parsedURL.Scheme
+		if parsedURL.Opaque != "" {
+			parsedURL, err = url.Parse(strings.Replace(address, ":", "://", 1))
+			if err != nil {
+				return "", "", "", "", errors.Wrap(err, "failed to parse BMC address information")
+
+			}
+		}
+		port = parsedURL.Port()
+		host = parsedURL.Hostname()
+		if parsedURL.Scheme == "" {
+			bmcType = "ipmi"
+			if host == "" {
+				// If there was no scheme at all, the hostname was
+				// interpreted as a path.
+				host = parsedURL.Path
+			}
+		} else {
+			path = parsedURL.Path
+		}
+	}
+	return bmcType, host, port, path, nil
+}
+
+// NewAccessDetails creates an AccessDetails structure from the URL
+// for a BMC.
+func NewAccessDetails(address string) (AccessDetails, error) {
+
+	bmcType, host, port, path, err := getTypeHostPort(address)
+	if err != nil {
+		return nil, err
+	}
+
+	var addr AccessDetails
+	switch bmcType {
+	case "ipmi", "libvirt":
+		addr = &ipmiAccessDetails{
+			bmcType:  bmcType,
+			portNum:  port,
+			hostname: host,
+		}
+	case "idrac", "idrac+http", "idrac+https":
+		addr = &iDracAccessDetails{
+			bmcType:  bmcType,
+			portNum:  port,
+			hostname: host,
+			path:     path,
+		}
+	default:
+		err = &UnknownBMCTypeError{address, bmcType}
+	}
+
+	return addr, err
+}

--- a/vendor/github.com/metal3-io/baremetal-operator/pkg/bmc/credentials.go
+++ b/vendor/github.com/metal3-io/baremetal-operator/pkg/bmc/credentials.go
@@ -1,0 +1,18 @@
+package bmc
+
+// Credentials holds the information for authenticating with the BMC.
+type Credentials struct {
+	Username string
+	Password string
+}
+
+// Validate returns an error if the credentials are invalid
+func (creds Credentials) Validate() error {
+	if creds.Username == "" {
+		return &CredentialsValidationError{message: "Missing BMC connection detail 'username' in credentials"}
+	}
+	if creds.Password == "" {
+		return &CredentialsValidationError{message: "Missing BMC connection details 'password' in credentials"}
+	}
+	return nil
+}

--- a/vendor/github.com/metal3-io/baremetal-operator/pkg/bmc/errors.go
+++ b/vendor/github.com/metal3-io/baremetal-operator/pkg/bmc/errors.go
@@ -1,0 +1,28 @@
+package bmc
+
+import (
+	"fmt"
+)
+
+// UnknownBMCTypeError is returned when the provided BMC address cannot be
+// mapped to a driver.
+type UnknownBMCTypeError struct {
+	address string
+	bmcType string
+}
+
+func (e UnknownBMCTypeError) Error() string {
+	return fmt.Sprintf("Unknown BMC type '%s' for address %s",
+		e.bmcType, e.address)
+}
+
+// CredentialsValidationError is returned when the provided BMC credentials
+// are invalid (e.g. null)
+type CredentialsValidationError struct {
+	message string
+}
+
+func (e CredentialsValidationError) Error() string {
+	return fmt.Sprintf("Validation error with BMC credentials: %s",
+		e.message)
+}

--- a/vendor/github.com/metal3-io/baremetal-operator/pkg/bmc/idrac.go
+++ b/vendor/github.com/metal3-io/baremetal-operator/pkg/bmc/idrac.go
@@ -1,0 +1,52 @@
+package bmc
+
+import (
+	"strings"
+)
+
+type iDracAccessDetails struct {
+	bmcType  string
+	portNum  string
+	hostname string
+	path     string
+}
+
+func (a *iDracAccessDetails) Type() string {
+	return a.bmcType
+}
+
+// NeedsMAC returns true when the host is going to need a separate
+// port created rather than having it discovered.
+func (a *iDracAccessDetails) NeedsMAC() bool {
+	return false
+}
+
+func (a *iDracAccessDetails) Driver() string {
+	return "idrac"
+}
+
+// DriverInfo returns a data structure to pass as the DriverInfo
+// parameter when creating a node in Ironic. The structure is
+// pre-populated with the access information, and the caller is
+// expected to add any other information that might be needed (such as
+// the kernel and ramdisk locations).
+func (a *iDracAccessDetails) DriverInfo(bmcCreds Credentials) map[string]interface{} {
+	result := map[string]interface{}{
+		"drac_username": bmcCreds.Username,
+		"drac_password": bmcCreds.Password,
+		"drac_address":  a.hostname,
+	}
+
+	schemes := strings.Split(a.bmcType, "+")
+	if len(schemes) > 1 {
+		result["drac_protocol"] = schemes[1]
+	}
+	if a.portNum != "" {
+		result["drac_port"] = a.portNum
+	}
+	if a.path != "" {
+		result["drac_path"] = a.path
+	}
+
+	return result
+}

--- a/vendor/github.com/metal3-io/baremetal-operator/pkg/bmc/ipmi.go
+++ b/vendor/github.com/metal3-io/baremetal-operator/pkg/bmc/ipmi.go
@@ -1,0 +1,47 @@
+package bmc
+
+type ipmiAccessDetails struct {
+	bmcType  string
+	portNum  string
+	hostname string
+}
+
+const ipmiDefaultPort = "623"
+
+func (a *ipmiAccessDetails) Type() string {
+	return a.bmcType
+}
+
+// NeedsMAC returns true when the host is going to need a separate
+// port created rather than having it discovered.
+func (a *ipmiAccessDetails) NeedsMAC() bool {
+	// libvirt-based hosts used for dev and testing require a MAC
+	// address, specified as part of the host, but we don't want the
+	// provisioner to have to know the rules about which drivers
+	// require what so we hide that detail inside this class and just
+	// let the provisioner know that "some" drivers require a MAC and
+	// it should ask.
+	return a.bmcType == "libvirt"
+}
+
+func (a *ipmiAccessDetails) Driver() string {
+	return "ipmi"
+}
+
+// DriverInfo returns a data structure to pass as the DriverInfo
+// parameter when creating a node in Ironic. The structure is
+// pre-populated with the access information, and the caller is
+// expected to add any other information that might be needed (such as
+// the kernel and ramdisk locations).
+func (a *ipmiAccessDetails) DriverInfo(bmcCreds Credentials) map[string]interface{} {
+	result := map[string]interface{}{
+		"ipmi_port":     a.portNum,
+		"ipmi_username": bmcCreds.Username,
+		"ipmi_password": bmcCreds.Password,
+		"ipmi_address":  a.hostname,
+	}
+	if a.portNum == "" {
+		result["ipmi_port"] = ipmiDefaultPort
+	}
+	return result
+}

--- a/vendor/github.com/metal3-io/baremetal-operator/pkg/hardware/profile.go
+++ b/vendor/github.com/metal3-io/baremetal-operator/pkg/hardware/profile.go
@@ -1,0 +1,98 @@
+package hardware
+
+import (
+	"fmt"
+)
+
+const (
+	// DefaultProfileName is the default hardware profile to use when
+	// no other profile matches.
+	DefaultProfileName string = "unknown"
+)
+
+// Profile holds the settings for a class of hardware.
+type Profile struct {
+	// Name holds the profile name
+	Name string
+
+	// RootDeviceHints holds the suggestions for placing the storage
+	// for the root filesystem.
+	RootDeviceHints RootDeviceHints
+
+	// RootGB is the size of the root volume in GB
+	RootGB int
+
+	// LocalGB is the size of something(?)
+	LocalGB int
+
+	// CPUArch is the architecture of the CPU.
+	CPUArch string
+}
+
+// RootDeviceHints holds the hints for specifying the storage location
+// for the root filesystem for the image.
+//
+// NOTE(dhellmann): Valid ironic hints are: "vendor,
+// wwn_vendor_extension, wwn_with_extension, by_path, serial, wwn,
+// size, rotational, name, hctl, model"
+type RootDeviceHints struct {
+	// A device name like "/dev/vda"
+	DeviceName string
+
+	// A SCSI bus address like 0:0:0:0
+	HCTL string
+}
+
+var profiles = make(map[string]Profile)
+
+func init() {
+	profiles[DefaultProfileName] = Profile{
+		Name: DefaultProfileName,
+		RootDeviceHints: RootDeviceHints{
+			DeviceName: "/dev/sda",
+		},
+		RootGB:  10,
+		LocalGB: 50,
+		CPUArch: "x86_64",
+	}
+
+	profiles["libvirt"] = Profile{
+		Name: "libvirt",
+		RootDeviceHints: RootDeviceHints{
+			DeviceName: "/dev/vda",
+		},
+		RootGB:  10,
+		LocalGB: 50,
+		CPUArch: "x86_64",
+	}
+
+	profiles["dell"] = Profile{
+		Name: "dell",
+		RootDeviceHints: RootDeviceHints{
+			HCTL: "0:0:0:0",
+		},
+		RootGB:  10,
+		LocalGB: 50,
+		CPUArch: "x86_64",
+	}
+
+	profiles["dell-raid"] = Profile{
+		Name: "dell-raid",
+		RootDeviceHints: RootDeviceHints{
+			HCTL: "0:2:0:0",
+		},
+		RootGB:  10,
+		LocalGB: 50,
+		CPUArch: "x86_64",
+	}
+
+}
+
+// GetProfile returns the named profile
+func GetProfile(name string) (Profile, error) {
+	profile, ok := profiles[name]
+	if !ok {
+		return Profile{}, fmt.Errorf("No hardware profile named %q", name)
+	}
+	return profile, nil
+}

--- a/vendor/github.com/openshift/api/config/v1/types_infrastructure.go
+++ b/vendor/github.com/openshift/api/config/v1/types_infrastructure.go
@@ -41,8 +41,8 @@ type InfrastructureStatus struct {
 	// value controls whether infrastructure automation such as service load
 	// balancers, dynamic volume provisioning, machine creation and deletion, and
 	// other integrations are enabled. If None, no infrastructure automation is
-	// enabled. Allowed values are "AWS", "Azure", "GCP", "Libvirt", "OpenStack",
-	// "BareMetal", "VSphere", and "None". Individual components may not support
+	// enabled. Allowed values are "AWS", "Azure", "BareMetal", "GCP", "Libvirt",
+	// "OpenStack", "VSphere", and "None". Individual components may not support
 	// all platforms, and must handle unrecognized platforms as None if they do
 	// not support that platform.
 	Platform PlatformType `json:"platform,omitempty"`
@@ -88,9 +88,6 @@ const (
 
 	// NonePlatformType means there is no infrastructure provider.
 	NonePlatformType PlatformType = "None"
-
-	// BareMetalPlatform represents bare metal infrastructure.
-	BareMetalPlatform PlatformType = "BareMetal"
 
 	// VSpherePlatformType represents VMWare vSphere infrastructure.
 	VSpherePlatformType PlatformType = "VSphere"


### PR DESCRIPTION
Based on 4.2 PR, which needs to get in first.  Goes along with https://github.com/openshift-metal3/dev-scripts/pull/578

Fixes https://github.com/openshift-metal3/kni-installer/issues/57

Some to-dos:
- [ ] Deal with image URL's, can we take them out of the install-config and use known adresses?
- [ ] Support creating the worker Ironic node objects (e.g. all the hosts we know about)
- [x] Use the default profile in BMO when hardwareProfile is empty
