### PR TITLE
vendor: update terraform-provider-ironic to v0.1.3

### DIFF
--- a/pkg/terraform/exec/plugins/Gopkg.lock
+++ b/pkg/terraform/exec/plugins/Gopkg.lock
@@ -727,12 +727,12 @@
   version = "v1.0.0"
 
 [[projects]]
-  digest = "1:a134ebe9bd265156f476db135a9d65e8474a416b70a3849ad06bbebde984b4a0"
+  digest = "1:61f1cd67d9c6ce439fb943b0f680fa4527d3913b4e895821d592689ffd7b02f3"
   name = "github.com/openshift-metalkube/terraform-provider-ironic"
   packages = ["ironic"]
   pruneopts = "NUT"
-  revision = "cce53c4cd7024e50b99cec489145f83d360752de"
-  version = "v0.1.2"
+  revision = "e16eaebdfdb17fc6883695b932786eb588625a95"
+  version = "v0.1.3"
 
 [[projects]]
   branch = "master"

--- a/pkg/terraform/exec/plugins/Gopkg.toml
+++ b/pkg/terraform/exec/plugins/Gopkg.toml
@@ -66,4 +66,4 @@ ignored = [
 
 [[constraint]]
   name = "github.com/openshift-metalkube/terraform-provider-ironic"
-  version = "v0.1.2"
+  version = "v0.1.3"

--- a/pkg/terraform/exec/plugins/vendor/github.com/openshift-metalkube/terraform-provider-ironic/ironic/resource_ironic_allocation_v1.go
+++ b/pkg/terraform/exec/plugins/vendor/github.com/openshift-metalkube/terraform-provider-ironic/ironic/resource_ironic_allocation_v1.go
@@ -35,6 +35,7 @@ func resourceAllocationV1() *schema.Resource {
 				},
 				Optional: true,
 				ForceNew: true,
+				Computed: true,
 			},
 			"traits": {
 				Type: schema.TypeList,

--- a/pkg/terraform/exec/plugins/vendor/github.com/openshift-metalkube/terraform-provider-ironic/ironic/resource_ironic_node_v1.go
+++ b/pkg/terraform/exec/plugins/vendor/github.com/openshift-metalkube/terraform-provider-ironic/ironic/resource_ironic_node_v1.go
@@ -27,7 +27,7 @@ func resourceNodeV1() *schema.Resource {
 			"boot_interface": {
 				Type:     schema.TypeString,
 				Optional: true,
-				Default:  "ipxe",
+				Computed: true,
 			},
 			"clean": {
 				Type:     schema.TypeBool,
@@ -36,16 +36,17 @@ func resourceNodeV1() *schema.Resource {
 			"conductor_group": {
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 			},
 			"console_interface": {
 				Type:     schema.TypeString,
 				Optional: true,
-				Default:  "no-console",
+				Computed: true,
 			},
 			"deploy_interface": {
 				Type:     schema.TypeString,
 				Optional: true,
-				Default:  "direct",
+				Computed: true,
 			},
 			"driver": {
 				Type:     schema.TypeString,
@@ -82,7 +83,7 @@ func resourceNodeV1() *schema.Resource {
 			"inspect_interface": {
 				Type:     schema.TypeString,
 				Optional: true,
-				Default:  "inspector",
+				Computed: true,
 			},
 			"instance_uuid": {
 				Type:     schema.TypeString,
@@ -103,27 +104,27 @@ func resourceNodeV1() *schema.Resource {
 			"management_interface": {
 				Type:     schema.TypeString,
 				Optional: true,
-				Default:  "ipmitool",
+				Computed: true,
 			},
 			"network_interface": {
 				Type:     schema.TypeString,
 				Optional: true,
-				Default:  "noop",
+				Computed: true,
 			},
 			"power_interface": {
 				Type:     schema.TypeString,
 				Optional: true,
-				Default:  "ipmitool",
+				Computed: true,
 			},
 			"raid_interface": {
 				Type:     schema.TypeString,
 				Optional: true,
-				Default:  "no-raid",
+				Computed: true,
 			},
 			"rescue_interface": {
 				Type:     schema.TypeString,
 				Optional: true,
-				Default:  "no-rescue",
+				Computed: true,
 			},
 			"resource_class": {
 				Type:     schema.TypeString,
@@ -132,16 +133,17 @@ func resourceNodeV1() *schema.Resource {
 			"storage_interface": {
 				Type:     schema.TypeString,
 				Optional: true,
-				Default:  "noop",
+				Computed: true,
 			},
 			"vendor_interface": {
 				Type:     schema.TypeString,
 				Optional: true,
-				Default:  "ipmitool",
+				Computed: true,
 			},
 			"owner": {
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 			},
 			"ports": {
 				Type:     schema.TypeSet,
@@ -170,6 +172,7 @@ func resourceNodeV1() *schema.Resource {
 			"power_state_timeout": {
 				Type:     schema.TypeInt,
 				Optional: true,
+				Computed: true,
 			},
 		},
 	}


### PR DESCRIPTION
This should fix most of the warnings from the upgrade to the new version
of terraform.

This should be merged after https://github.com/openshift-metal3/kni-installer/pull/96