### PR TITLE
Add ingress_vip to installer survey

### DIFF
--- a/pkg/asset/cluster/baremetal/baremetal.go
+++ b/pkg/asset/cluster/baremetal/baremetal.go
@@ -13,5 +13,6 @@ func Metadata(infraID string, config *types.InstallConfig) *baremetal.Metadata {
 		LibvirtURI: config.Platform.BareMetal.LibvirtURI,
 		IronicURI:  config.Platform.BareMetal.IronicURI,
 		APIVIP:     config.Platform.BareMetal.APIVIP,
+		IngressVIP: config.Platform.BareMetal.IngressVIP,
 	}
 }

--- a/pkg/types/baremetal/defaults/platform.go
+++ b/pkg/types/baremetal/defaults/platform.go
@@ -16,6 +16,7 @@ const (
 	ProvisioningBridge = "provisioning"
 	HardwareProfile    = "default"
 	APIVIP             = ""
+	IngressVIP         = ""
 )
 
 // SetPlatformDefaults sets the defaults for the platform.
@@ -50,6 +51,17 @@ func SetPlatformDefaults(p *baremetal.Platform, c *types.InstallConfig) {
 			p.APIVIP = fmt.Sprintf("DNS lookup failure: %s", err.Error())
 		} else {
 			p.APIVIP = vip[0]
+		}
+	}
+
+	if p.IngressVIP == IngressVIP {
+		// This name should resolve to exactly one address
+		vip, err := net.LookupHost("test.apps." + c.ClusterDomain())
+		if err != nil {
+			// This will fail validation and abort the install
+			p.IngressVIP = fmt.Sprintf("DNS lookup failure: %s", err.Error())
+		} else {
+			p.IngressVIP = vip[0]
 		}
 	}
 }

--- a/pkg/types/baremetal/metadata.go
+++ b/pkg/types/baremetal/metadata.go
@@ -5,4 +5,5 @@ type Metadata struct {
 	LibvirtURI string `json:"libvirt_uri"`
 	IronicURI  string `json:"ironic_uri"`
 	APIVIP     string `json:"api_vip"`
+	IngressVIP string `json:"ingress_vip"`
 }

--- a/pkg/types/baremetal/platform.go
+++ b/pkg/types/baremetal/platform.go
@@ -60,4 +60,7 @@ type Platform struct {
 
 	// APIVIP is the VIP to use for internal API communication
 	APIVIP string `json:"api_vip"`
+
+	// IngressVIP is the VIP to use for ingress traffic
+	IngressVIP string `json:"ingress_vip"`
 }

--- a/pkg/types/baremetal/validation/platform.go
+++ b/pkg/types/baremetal/validation/platform.go
@@ -36,5 +36,9 @@ func ValidatePlatform(p *baremetal.Platform, fldPath *field.Path) field.ErrorLis
 	if err := validate.IP(p.APIVIP); err != nil {
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("api_vip"), p.APIVIP, err.Error()))
 	}
+
+	if err := validate.IP(p.IngressVIP); err != nil {
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("ingress_vip"), p.IngressVIP, err.Error()))
+	}
 	return allErrs
 }


### PR DESCRIPTION
We want to get away from looking up vips at deploy time from DNS.
Instead, they should be specified in install-config.yaml and looked
up from that data.

This adds ingress_vip as a configuration option like the previously
added api_vip.