### PR TITLE
WIP: pkg/asset/manifests/infrastructure: Set status.platformStatus.ba…

### DIFF
--- a/pkg/asset/manifests/infrastructure.go
+++ b/pkg/asset/manifests/infrastructure.go
@@ -54,26 +54,6 @@ func (i *Infrastructure) Generate(dependencies asset.Parents) error {
 	cloudproviderconfig := &CloudProviderConfig{}
 	dependencies.Get(clusterID, installConfig, cloudproviderconfig)
 
-	var platform configv1.PlatformType
-	switch installConfig.Config.Platform.Name() {
-	case aws.Name:
-		platform = configv1.AWSPlatformType
-	case none.Name:
-		platform = configv1.NonePlatformType
-	case libvirt.Name:
-		platform = configv1.LibvirtPlatformType
-	case openstack.Name:
-		platform = configv1.OpenStackPlatformType
-	case vsphere.Name:
-		platform = configv1.VSpherePlatformType
-	case azure.Name:
-		platform = configv1.AzurePlatformType
-	case baremetal.Name:
-		platform = configv1.BareMetalPlatformType
-	default:
-		platform = configv1.NonePlatformType
-	}
-
 	config := &configv1.Infrastructure{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: configv1.SchemeGroupVersion.String(),
@@ -85,12 +65,37 @@ func (i *Infrastructure) Generate(dependencies asset.Parents) error {
 		},
 		Status: configv1.InfrastructureStatus{
 			InfrastructureName:   clusterID.InfraID,
-			Platform:             platform,
 			APIServerURL:         getAPIServerURL(installConfig.Config),
 			APIServerInternalURL: getInternalAPIServerURL(installConfig.Config),
 			EtcdDiscoveryDomain:  getEtcdDiscoveryDomain(installConfig.Config),
+			PlatformStatus:       &configv1.PlatformStatus{},
 		},
 	}
+
+	switch installConfig.Config.Platform.Name() {
+	case aws.Name:
+			config.Status.PlatformStatus.Type = configv1.AWSPlatformType
+	case none.Name:
+			config.Status.PlatformStatus.Type = configv1.NonePlatformType
+	case libvirt.Name:
+			config.Status.PlatformStatus.Type = configv1.LibvirtPlatformType
+	case openstack.Name:
+			config.Status.PlatformStatus.Type = configv1.OpenStackPlatformType
+	case vsphere.Name:
+			config.Status.PlatformStatus.Type = configv1.VSpherePlatformType
+	case azure.Name:
+			config.Status.PlatformStatus.Type = configv1.AzurePlatformType
+	case baremetal.Name:
+			config.Status.PlatformStatus.Type = configv1.BareMetalPlatformType
+			config.Status.PlatformStatus.BareMetal = &configv1.BareMetalPlatformStatus{
+					APIVIP:     installConfig.Config.Platform.BareMetal.APIVIP,
+					DNSVIP:     installConfig.Config.Platform.BareMetal.DNSVIP,
+					IngressVIP: installConfig.Config.Platform.BareMetal.IngressVIP,
+			}
+	default:
+		config.Status.PlatformStatus.Type = configv1.NonePlatformType
+	}
+	config.Status.Platform = config.Status.PlatformStatus.Type
 
 	if cloudproviderconfig.ConfigMap != nil {
 		// set the configmap reference.


### PR DESCRIPTION
…remetal.apivip

Using openshift/api@6a276bd3 (config/v1/types_infrastructure: Add BareMetal
status for BareMetal platform, 2019-06-11, openshift/api#348) so static
pods can use the API VIP in their configuration.