### PR TITLE
Add build flags for baremetal destroy

### DIFF
--- a/pkg/destroy/baremetal/baremetal.go
+++ b/pkg/destroy/baremetal/baremetal.go
@@ -1,3 +1,5 @@
+// +build ironic
+
 package baremetal
 
 import (

--- a/pkg/destroy/baremetal/register.go
+++ b/pkg/destroy/baremetal/register.go
@@ -1,3 +1,5 @@
+// +build ironic
+
 // Package baremetal provides a cluster-destroyer for bare metal clusters.
 package baremetal
 


### PR DESCRIPTION
Otherwise building installer without baremetal fails with errors, e.g.
when just building an installer for openstack you end up with:

```
pkg/destroy/baremetal/baremetal.go:24:12: undefined: "github.com/openshift/installer/vendor/github.com/libvirt/libvirt-go".NewConnect
```

libvirt also conditionally builds their destroy package for the same
reasons.