### PR TITLE
Rename ApiVIP to APIVIP per go-lint

### DIFF
--- a/pkg/asset/installconfig/baremetal/baremetal.go
+++ b/pkg/asset/installconfig/baremetal/baremetal.go
@@ -76,7 +76,7 @@ func Platform() (*baremetal.Platform, error) {
 			Prompt: &survey.Input{
 				Message: "API VIP",
 				Help:    "The VIP to be used for internal API communication. If blank, the address will be looked up from DNS.",
-				Default: baremetaldefaults.ApiVIP,
+				Default: baremetaldefaults.APIVIP,
 			},
 			Validate: ipValidator,
 		},
@@ -124,7 +124,7 @@ func uriValidator(ans interface{}) error {
 }
 
 func ipValidator(ans interface{}) error {
-	if (ans.(string) != baremetaldefaults.ApiVIP) {
+	if (ans.(string) != baremetaldefaults.APIVIP) {
 		return validate.IP(ans.(string))
 	}
 	return nil

--- a/pkg/types/baremetal/defaults/platform.go
+++ b/pkg/types/baremetal/defaults/platform.go
@@ -15,7 +15,7 @@ const (
 	ExternalBridge     = "baremetal"
 	ProvisioningBridge = "provisioning"
 	HardwareProfile    = "default"
-	ApiVIP = ""
+	APIVIP             = ""
 )
 
 // SetPlatformDefaults sets the defaults for the platform.
@@ -42,7 +42,7 @@ func SetPlatformDefaults(p *baremetal.Platform, c *types.InstallConfig) {
 		}
 	}
 
-	if p.APIVIP == ApiVIP {
+	if p.APIVIP == APIVIP {
 		// This name should resolve to exactly one address
 		vip, err := net.LookupHost("api." + c.ClusterDomain())
 		if err != nil {


### PR DESCRIPTION
Lint locally didn't complain about this one but openshift CI is.