### PR TITLE
Revert "Fix typo in machinepools json annotation"

### DIFF
--- a/pkg/types/machinepools.go
+++ b/pkg/types/machinepools.go
@@ -58,7 +58,7 @@ type MachinePoolPlatform struct {
 	Azure *azure.MachinePool `json:"azure,omitempty"`
 
 	// BareMetal is the configuration used when installing on bare metal.
-	BareMetal *baremetal.MachinePool `json:"baremetal,omitempty"`
+	BareMetal *baremetal.MachinePool `json:"openstack,omitempty"`
 }
 
 // Name returns a string representation of the platform (e.g. "aws" if


### PR DESCRIPTION
Reverts openshift-metal3/kni-installer#116

This means we start using  https://github.com/openshift-metal3/kni-installer/blob/master/pkg/asset/machines/master.go#L160 which doesn't seem to work, investigation why is in-progress but we may be best to revert this in the meantime.