### PR TITLE
Revert "Revert "Fix typo in machinepools json annotation""

### DIFF
--- a/pkg/types/machinepools.go
+++ b/pkg/types/machinepools.go
@@ -58,7 +58,7 @@ type MachinePoolPlatform struct {
 	Azure *azure.MachinePool `json:"azure,omitempty"`
 
 	// BareMetal is the configuration used when installing on bare metal.
-	BareMetal *baremetal.MachinePool `json:"openstack,omitempty"`
+	BareMetal *baremetal.MachinePool `json:"baremetal,omitempty"`
 }
 
 // Name returns a string representation of the platform (e.g. "aws" if


### PR DESCRIPTION
This appears to be because the install-config requires a minor update to match the machinepools platform name, WIP pending confirmation in CI via a dev-scripts PR.

Reverts openshift-metal3/kni-installer#124