### PR TITLE
Fix typo in JSON for baremetal platform

### DIFF
--- a/pkg/types/baremetal/platform.go
+++ b/pkg/types/baremetal/platform.go
@@ -4,7 +4,7 @@ package baremetal
 type BMC struct {
 	Username string `json:"username"`
 	Password string `json:"password"`
-	Address  string `json":"address"`
+	Address  string `json:"address"`
 }
 
 // Host stores all the configuration data for a baremetal host.


### PR DESCRIPTION
I was looking at the various commits since the last release until now, and I noticed this typo. I do not think this is why things are failing (but neither did we think the last typo in a JSON annotation was all that serious).