### PR TITLE
Start a document explaining baremetal bootstrap assets.

### DIFF
--- a/data/data/bootstrap/baremetal/README.md
+++ b/data/data/bootstrap/baremetal/README.md
@@ -1,0 +1,34 @@
+# Bare Metal IPI Bootstrap Assets
+
+The `baremetal` platform (IPI for Bare Metal hosts) includes some additional
+assets on the bootstrap node for automating some infrastructure requirements
+that would have normally been handled by some cloud infrastructure service.
+This document explains these pieces and what they accomplish.
+
+## API failover from bootstrap to masters
+
+One problem being addressed is that the installation process expects the API to
+first be reachable on the bootstrap VM, but later in the installation process,
+the API comes up on the masters that have been deployed.
+
+In the `baremetal` platform, the failover of the API server is done by using a
+VIP (Virtual IP) that has been configured as part of `install-config.yaml` and
+then managed by `keepalived`.
+
+The API VIP first resides on the bootstrap VM.  Once the master nodes come up,
+the VIP will move to the masters.  This happens because the masters will be
+running `keepalived` with a higher priority set in their `keepalived`
+configuration for the API VIP.
+
+Relevant files:
+* **files/etc/keepalived/keepalived.conf.tmpl** - `keepalived` configuration
+  template
+* **files/usr/local/bin/keepalived.sh** - This script runs before `keepalived`
+  starts and generates the `keepalived` configuration file from the template.
+* **systemd/units/keepalived.service** - systemd unit file for `keepalived`.
+  This runs `keepalived.sh` to generate the proper configuration from the
+  template and then runs podman to launch `keepalived`.
+
+## Internal DNS
+
+TODO

--- a/data/data/bootstrap/baremetal/README.md
+++ b/data/data/bootstrap/baremetal/README.md
@@ -31,4 +31,22 @@ Relevant files:
 
 ## Internal DNS
 
-TODO
+Another key area addressed with some of the bootstrap assets is DNS.  The goal
+of these changes is to automate as much of the DNS requirements internal to the
+cluster as possible, leaving only a small amount of public DNS work to be
+done.  Because of these changes, the only external DNS records that the cluster
+administrator must create are:
+
+* api.<cluster-name>.<base-domain>
+* *.apps.<cluster-name>.<base-domain>
+
+TODO - explain how this works ...
+
+Relevant files:
+* files/etc/coredns/Corefile
+* files/etc/keepalived/keepalived.conf.tmpl
+* files/etc/dhcp/dhclient.conf
+* files/usr/local/bin/fletcher8
+* files/usr/local/bin/get_vip_subnet_cidr
+* files/usr/local/bin/coredns.sh
+* systemd/units/coredns.service

--- a/data/data/bootstrap/baremetal/files/etc/keepalived/keepalived.conf.tmpl
+++ b/data/data/bootstrap/baremetal/files/etc/keepalived/keepalived.conf.tmpl
@@ -1,5 +1,8 @@
 # Configuration template for Keepalived, which is used to manage the DNS and
 # API VIPs.
+#
+# For more information, see installer/data/data/bootstrap/baremetal/README.md
+#
 
 vrrp_instance ${CLUSTER_NAME}_API {
     state BACKUP

--- a/data/data/bootstrap/baremetal/files/usr/local/bin/keepalived.sh
+++ b/data/data/bootstrap/baremetal/files/usr/local/bin/keepalived.sh
@@ -1,4 +1,9 @@
 #!/usr/bin/env bash
+
+#
+# For more information, see installer/data/data/bootstrap/baremetal/README.md
+#
+
 set -e
 
 # Script to configure and run the Keepalived instance used to manage the DNS

--- a/data/data/bootstrap/baremetal/systemd/units/keepalived.service
+++ b/data/data/bootstrap/baremetal/systemd/units/keepalived.service
@@ -1,4 +1,7 @@
 # Systemd service file used to start the bootstrap Keepalived instance.
+#
+# For more information, see installer/data/data/bootstrap/baremetal/README.md
+#
 
 [Unit]
 Description=Manage node VIPs with keepalived


### PR DESCRIPTION
This patch starts a document that tries to explain the purpose of all of the `baremetal` platform assets on the bootstrap VM.  The DNS part still needs more work, though.

Part of issue #144 