### PR TITLE
Add design doc for bare metal IPI networking

### DIFF
--- a/data/data/bootstrap/baremetal/README.md
+++ b/data/data/bootstrap/baremetal/README.md
@@ -3,22 +3,16 @@
 The `baremetal` platform (IPI for Bare Metal hosts) includes some additional
 assets on the bootstrap node for automating some infrastructure requirements
 that would have normally been handled by some cloud infrastructure service.
-This document explains these pieces and what they accomplish.
+The [Bare Metal IPI Networking Infrastructure design document]
+(../../../../doc/design/baremetal/networking-infrastructure.md) covers the
+high-level background, and this document explains these bootstrap assets in
+more detail.
 
-## API failover from bootstrap to masters
+## API failover from bootstrap to control plane machines
 
-One problem being addressed is that the installation process expects the API to
-first be reachable on the bootstrap VM, but later in the installation process,
-the API comes up on the masters that have been deployed.
-
-In the `baremetal` platform, the failover of the API server is done by using a
-VIP (Virtual IP) that has been configured as part of `install-config.yaml` and
-then managed by `keepalived`.
-
-The API VIP first resides on the bootstrap VM.  Once the master nodes come up,
-the VIP will move to the masters.  This happens because the masters will be
-running `keepalived` with a higher priority set in their `keepalived`
-configuration for the API VIP.
+`keepalived` is used to manage the failover of a VIP (Virtual IP) for the API
+server. This VIP first resides on the bootstrap VM. Once the master nodes come
+up, the VIP will move to the control plane machines.
 
 Relevant files:
 * **files/etc/keepalived/keepalived.conf.tmpl** - `keepalived` configuration
@@ -31,14 +25,8 @@ Relevant files:
 
 ## Internal DNS
 
-Another key area addressed with some of the bootstrap assets is DNS.  The goal
-of these changes is to automate as much of the DNS requirements internal to the
-cluster as possible, leaving only a small amount of public DNS work to be
-done.  Because of these changes, the only external DNS records that the cluster
-administrator must create are:
-
-* api.<cluster-name>.<base-domain>
-* *.apps.<cluster-name>.<base-domain>
+The bootstrap assets relating to DNS automate as much of the DNS requirements
+internal to the cluster as possible.
 
 TODO - explain how this works ...
 

--- a/docs/design/baremetal/networking-infrastructure.md
+++ b/docs/design/baremetal/networking-infrastructure.md
@@ -1,0 +1,47 @@
+# Bare Metal IPI Networking Infrastructure
+
+The `baremetal` platform (IPI for Bare Metal hosts) automates a number
+of networking infrastructure requirements that are handled on other
+platforms by cloud infrastructure services.
+
+## Load-balanced control plane access
+
+Access to the Kubernetes API (port 6443) from clients both external
+and internal to the cluster should be load-balanced across control
+plane machines.
+
+Access to Ignition configs (port 22623) from clients within the
+cluster should also be load-balanced across control plane machines.
+
+In both cases, the installation process expects these ports to be
+reachable on the bootstrap VM at first and then later on the
+newly-deployed control plane machines.
+
+On other platforms (for example, see [the AWS UPI
+instructions](../../user/aws/install_upi.md)) an external
+load-balancer is required to be configured in advance in order to
+provide this access.
+
+In the `baremetal` platform, a VIP (Virtual IP) is used to provide
+failover of the API server across the control plane machines
+(including the bootstrap VM). This "API VIP" is provided by the user
+as an `install-config.yaml` parameter and the installation process
+configures `keepalived` to manage this VIP.
+
+The API VIP first resides on the bootstrap VM. The `keepalived`
+instance here is managed by systemd and a script is used to generate
+the `keepalived` configuration before launching the service using
+`podman`. See [here](../../../data/data/bootstrap/baremetal/README.md)
+for more informations about the relevant bootstrap assets.
+
+Once the control plane machines come up, the VIP will move to the one
+of these machines. This happens because the `keepalived` instances on
+control plane machines are configured (in `keepalived.conf`) with a
+higher
+[VRRP](https://en.wikipedia.org/wiki/Virtual_Router_Redundancy_Protocol)
+priority. These `keepalived` instances are run as [static
+pods](https://kubernetes.io/docs/tasks/administer-cluster/static-pod/)
+and the relevant assets are [rendered by the Machine Config
+Operator](https://github.com/openshift/machine-config-operator/pull/795). See
+[here](FIXME: link to a README in MCO) for more information about
+these assets.


### PR DESCRIPTION
This document can cover the high-level requirements and design, while
README files closer to the relevant assets can cover the details.