### PR TITLE
data/data/bootstrap/baremetal: fix broken link in readme

### DIFF
--- a/data/data/bootstrap/baremetal/README.md
+++ b/data/data/bootstrap/baremetal/README.md
@@ -3,10 +3,10 @@
 The `baremetal` platform (IPI for Bare Metal hosts) includes some additional
 assets on the bootstrap node for automating some infrastructure requirements
 that would have normally been handled by some cloud infrastructure service.
-The [Bare Metal IPI Networking Infrastructure design document]
-(../../../../doc/design/baremetal/networking-infrastructure.md) covers the
-high-level background, and this document explains these bootstrap assets in
-more detail.
+The [Bare Metal IPI Networking Infrastructure design
+document](../../../../docs/design/baremetal/networking-infrastructure.md)
+covers the high-level background, and this document explains these
+bootstrap assets in more detail.
 
 ## API failover from bootstrap to control plane machines
 


### PR DESCRIPTION
The newline between ] and ( in markdown breaks the link, at least on
GitHub, and the correct path is docs, not doc.