### PR TITLE
vendor: bump terraform-provider-ironic to v0.1.5

### DIFF
--- a/pkg/terraform/exec/plugins/Gopkg.lock
+++ b/pkg/terraform/exec/plugins/Gopkg.lock
@@ -788,12 +788,12 @@
   version = "v1.0.0"
 
 [[projects]]
-  digest = "1:a0886267c60262a245d6eeb0be12bf8e165026ad088bce106b9c55c5d613144f"
+  digest = "1:5df7b7a9034063c1e46906a4b7042da319824f09f9f741614b724c2fd7d58c19"
   name = "github.com/openshift-metal3/terraform-provider-ironic"
   packages = ["ironic"]
   pruneopts = "NUT"
-  revision = "9f5bba54dad78c10ed572eb2541f8178a5500656"
-  version = "v0.1.4"
+  revision = "392753730a1dbbcc1ae580905e40590c196a13f9"
+  version = "v0.1.5"
 
 [[projects]]
   branch = "master"

--- a/pkg/terraform/exec/plugins/Gopkg.toml
+++ b/pkg/terraform/exec/plugins/Gopkg.toml
@@ -70,4 +70,4 @@ ignored = [
 
 [[constraint]]
   name = "github.com/openshift-metal3/terraform-provider-ironic"
-  version = "v0.1.3"
+  version = "v0.1.5"

--- a/pkg/terraform/exec/plugins/vendor/github.com/openshift-metal3/terraform-provider-ironic/ironic/data_source_ironic_introspection.go
+++ b/pkg/terraform/exec/plugins/vendor/github.com/openshift-metal3/terraform-provider-ironic/ironic/data_source_ironic_introspection.go
@@ -67,9 +67,9 @@ func dataSourceIronicIntrospection() *schema.Resource {
 }
 
 func dataSourceIronicIntrospectionRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(Clients).Inspector
-	if client == nil {
-		return fmt.Errorf("inspector endpoint was not defined")
+	client, err := meta.(*Clients).GetInspectorClient()
+	if err != nil {
+		return err
 	}
 
 	uuid := d.Get("uuid").(string)

--- a/pkg/terraform/exec/plugins/vendor/github.com/openshift-metal3/terraform-provider-ironic/ironic/provider.go
+++ b/pkg/terraform/exec/plugins/vendor/github.com/openshift-metal3/terraform-provider-ironic/ironic/provider.go
@@ -8,12 +8,86 @@ import (
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/terraform"
 	"log"
+	"net/http"
+	"sync"
+	"time"
 )
 
 // Clients stores the client connection information for Ironic and Inspector
 type Clients struct {
-	Ironic    *gophercloud.ServiceClient
-	Inspector *gophercloud.ServiceClient
+	ironic    *gophercloud.ServiceClient
+	inspector *gophercloud.ServiceClient
+
+	// Boolean that determines if Ironic API was previously determined to be available, we don't need to try every time.
+	ironicUp bool
+
+	// Boolean that determines we've already waited and the API never came up, we don't need to wait again.
+	ironicFailed bool
+
+	// Mutex so that only one resource being created by terraform checks at a time. There's no reason to have multiple
+	// resources calling out to the API.
+	ironicMux sync.Mutex
+
+	// Boolean that determines if Inspector API was previously determined to be available, we don't need to try every time.
+	inspectorUp bool
+
+	// Boolean that determines that we've already waited, and inspector API did not come up.
+	inspectorFailed bool
+
+	// Mutex so that only one resource being created by terraform checks at a time. There's no reason to have multiple
+	// resources calling out to the API.
+	inspectorMux sync.Mutex
+
+	timeout int
+}
+
+// GetIronicClient returns the API client for Ironic, optionally retrying to reach the API if timeout is set.
+func (c *Clients) GetIronicClient() (*gophercloud.ServiceClient, error) {
+	c.ironicMux.Lock()
+	defer c.ironicMux.Unlock()
+
+	// Ironic is UP, or user didn't ask us to check
+	if c.ironicUp || c.timeout == 0 {
+		return c.ironic, nil
+	}
+
+	if c.ironicFailed {
+		return nil, fmt.Errorf("could not contact API: timeout reached")
+	}
+
+	// Wait the specified interval for Ironic to come up
+	err := waitForAPI(c.timeout, c.ironic)
+	if err != nil {
+		c.ironicFailed = true
+		return nil, err
+
+	}
+
+	c.ironicUp = true
+	return c.ironic, nil
+}
+
+// GetInspectorClient returns the API client for Ironic, optionally retrying to reach the API if timeout is set.
+func (c *Clients) GetInspectorClient() (*gophercloud.ServiceClient, error) {
+	c.inspectorMux.Lock()
+	defer c.inspectorMux.Unlock()
+
+	if c.inspector == nil {
+		return nil, fmt.Errorf("no inspector endpoint was specified")
+	} else if c.inspectorUp || c.timeout == 0 {
+		return c.inspector, nil
+	} else if c.inspectorFailed {
+		return nil, fmt.Errorf("could not contact API: timeout reached")
+	}
+
+	err := waitForAPI(c.timeout, c.inspector)
+	if err != nil {
+		c.inspectorFailed = true
+		return nil, err
+	}
+
+	c.inspectorUp = true
+	return c.inspector, nil
 }
 
 // Provider Ironic
@@ -38,6 +112,12 @@ func Provider() terraform.ResourceProvider {
 				DefaultFunc: schema.EnvDefaultFunc("IRONIC_MICROVERSION", "1.52"),
 				Description: descriptions["microversion"],
 			},
+			"timeout": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Description: descriptions["timeout"],
+				Default:     0,
+			},
 		},
 		ResourcesMap: map[string]*schema.Resource{
 			"ironic_node_v1":       resourceNodeV1(),
@@ -59,6 +139,7 @@ func init() {
 		"url":          "The authentication endpoint for Ironic",
 		"inspector":    "The endpoint for Ironic inspector",
 		"microversion": "The microversion to use for Ironic",
+		"timeout":      "Wait at least the specified number of seconds for the API to become available",
 	}
 }
 
@@ -79,7 +160,7 @@ func configureProvider(schema *schema.ResourceData) (interface{}, error) {
 		return nil, err
 	}
 	ironic.Microversion = schema.Get("microversion").(string)
-	clients.Ironic = ironic
+	clients.ironic = ironic
 
 	inspectorURL := schema.Get("inspector").(string)
 	if inspectorURL != "" {
@@ -90,8 +171,48 @@ func configureProvider(schema *schema.ResourceData) (interface{}, error) {
 		if err != nil {
 			return nil, fmt.Errorf("could not configure inspector endpoint: %s", err.Error())
 		}
-		clients.Inspector = inspector
+		clients.inspector = inspector
 	}
 
-	return clients, err
+	clients.timeout = schema.Get("timeout").(int)
+
+	return &clients, err
+}
+
+// Retries an API until a timeout is reached. The timeout is approximate, we calculate approximately
+// the number of attempts that would equal that timeout. It's not exact, but it will be *at least* the
+// value specified.
+func waitForAPI(timeout int, client *gophercloud.ServiceClient) error {
+	var maxTries int
+	if timeout < 5 {
+		maxTries = 1
+	} else {
+		maxTries = timeout / 5
+	}
+	log.Printf("[DEBUG] Waiting for Ironic API to become available - max attempts is %d", maxTries)
+
+	httpClient := &http.Client{
+		Timeout: 5 * time.Second,
+	}
+
+	for tries := 1; tries <= maxTries; tries++ {
+		// FIXME(stbenjam): After we sleep at the end of the loop, *something* is changing log output to be discarded, and
+		// when we get woken up again, our logs aren't printed anymore until the end of the loop. Very odd error, possibly
+		// something in terraform is doing this.
+		log.Printf("[DEBUG] Trying to connect to API, attempt %d of %d\n", tries, maxTries)
+
+		r, err := httpClient.Get(client.Endpoint)
+		if err == nil {
+			statusCode := r.StatusCode
+			r.Body.Close()
+			if statusCode == http.StatusOK {
+				log.Printf("[DEBUG] API successfully connected.")
+				return nil
+			}
+		}
+
+		time.Sleep(5 * time.Second)
+	}
+
+	return fmt.Errorf("could not contact API: timeout reached")
 }

--- a/pkg/terraform/exec/plugins/vendor/github.com/openshift-metal3/terraform-provider-ironic/ironic/resource_ironic_allocation_v1.go
+++ b/pkg/terraform/exec/plugins/vendor/github.com/openshift-metal3/terraform-provider-ironic/ironic/resource_ironic_allocation_v1.go
@@ -68,7 +68,10 @@ func resourceAllocationV1() *schema.Resource {
 
 // Create an allocation, including driving Ironic's state machine
 func resourceAllocationV1Create(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(Clients).Ironic
+	client, err := meta.(*Clients).GetIronicClient()
+	if err != nil {
+		return err
+	}
 
 	result, err := allocations.Create(client, allocationSchemaToCreateOpts(d)).Extract()
 	if err != nil {
@@ -110,7 +113,10 @@ func resourceAllocationV1Create(d *schema.ResourceData, meta interface{}) error 
 
 // Read the allocation's data from Ironic
 func resourceAllocationV1Read(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(Clients).Ironic
+	client, err := meta.(*Clients).GetIronicClient()
+	if err != nil {
+		return err
+	}
 
 	result, err := allocations.Get(client, d.Id()).Extract()
 	if err != nil {
@@ -131,9 +137,12 @@ func resourceAllocationV1Read(d *schema.ResourceData, meta interface{}) error {
 
 // Delete an allocation from Ironic if it exists
 func resourceAllocationV1Delete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(Clients).Ironic
+	client, err := meta.(*Clients).GetIronicClient()
+	if err != nil {
+		return err
+	}
 
-	_, err := allocations.Get(client, d.Id()).Extract()
+	_, err = allocations.Get(client, d.Id()).Extract()
 	if _, ok := err.(gophercloud.ErrDefault404); ok {
 		return nil
 	}

--- a/pkg/terraform/exec/plugins/vendor/github.com/openshift-metal3/terraform-provider-ironic/ironic/resource_ironic_deployment.go
+++ b/pkg/terraform/exec/plugins/vendor/github.com/openshift-metal3/terraform-provider-ironic/ironic/resource_ironic_deployment.go
@@ -59,7 +59,10 @@ func resourceDeployment() *schema.Resource {
 
 // Create an deployment, including driving Ironic's state machine
 func resourceDeploymentCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(Clients).Ironic
+	client, err := meta.(*Clients).GetIronicClient()
+	if err != nil {
+		return err
+	}
 
 	// Reload the resource before returning
 	defer resourceDeploymentRead(d, meta)
@@ -94,7 +97,10 @@ func resourceDeploymentCreate(d *schema.ResourceData, meta interface{}) error {
 
 // Read the deployment's data from Ironic
 func resourceDeploymentRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(Clients).Ironic
+	client, err := meta.(*Clients).GetIronicClient()
+	if err != nil {
+		return err
+	}
 
 	// Ensure node exists first
 	id := d.Get("node_uuid").(string)
@@ -111,6 +117,10 @@ func resourceDeploymentRead(d *schema.ResourceData, meta interface{}) error {
 
 // Delete an deployment from Ironic - this cleans the node and returns it's state to 'available'
 func resourceDeploymentDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(Clients).Ironic
+	client, err := meta.(*Clients).GetIronicClient()
+	if err != nil {
+		return err
+	}
+
 	return ChangeProvisionStateToTarget(client, d.Id(), "deleted", nil)
 }

--- a/pkg/terraform/exec/plugins/vendor/github.com/openshift-metal3/terraform-provider-ironic/ironic/resource_ironic_node_v1.go
+++ b/pkg/terraform/exec/plugins/vendor/github.com/openshift-metal3/terraform-provider-ironic/ironic/resource_ironic_node_v1.go
@@ -180,7 +180,10 @@ func resourceNodeV1() *schema.Resource {
 
 // Create a node, including driving Ironic's state machine
 func resourceNodeV1Create(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(Clients).Ironic
+	client, err := meta.(*Clients).GetIronicClient()
+	if err != nil {
+		return err
+	}
 
 	// Create the node object in Ironic
 	createOpts := schemaToCreateOpts(d)
@@ -266,7 +269,10 @@ func resourceNodeV1Create(d *schema.ResourceData, meta interface{}) error {
 
 // Read the node's data from Ironic
 func resourceNodeV1Read(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(Clients).Ironic
+	client, err := meta.(*Clients).GetIronicClient()
+	if err != nil {
+		return err
+	}
 
 	node, err := nodes.Get(client, d.Id()).Extract()
 	if err != nil {
@@ -306,7 +312,10 @@ func resourceNodeV1Read(d *schema.ResourceData, meta interface{}) error {
 
 // Update a node's state based on the terraform config - TODO: handle everything
 func resourceNodeV1Update(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(Clients).Ironic
+	client, err := meta.(*Clients).GetIronicClient()
+	if err != nil {
+		return err
+	}
 
 	d.Partial(true)
 
@@ -403,7 +412,11 @@ func resourceNodeV1Update(d *schema.ResourceData, meta interface{}) error {
 
 // Delete a node from Ironic
 func resourceNodeV1Delete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(Clients).Ironic
+	client, err := meta.(*Clients).GetIronicClient()
+	if err != nil {
+		return err
+	}
+
 	if err := ChangeProvisionStateToTarget(client, d.Id(), "deleted", nil); err != nil {
 		return err
 	}

--- a/pkg/terraform/exec/plugins/vendor/github.com/openshift-metal3/terraform-provider-ironic/ironic/resource_ironic_port_v1.go
+++ b/pkg/terraform/exec/plugins/vendor/github.com/openshift-metal3/terraform-provider-ironic/ironic/resource_ironic_port_v1.go
@@ -50,7 +50,11 @@ func resourcePortV1() *schema.Resource {
 }
 
 func resourcePortV1Create(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(Clients).Ironic
+	client, err := meta.(*Clients).GetIronicClient()
+	if err != nil {
+		return err
+	}
+
 	opts := portSchemaToCreateOpts(d)
 	result, err := ports.Create(client, opts).Extract()
 	if err != nil {
@@ -62,7 +66,11 @@ func resourcePortV1Create(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourcePortV1Read(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(Clients).Ironic
+	client, err := meta.(*Clients).GetIronicClient()
+	if err != nil {
+		return err
+	}
+
 	port, err := ports.Get(client, d.Id()).Extract()
 	if err != nil {
 		return err


### PR DESCRIPTION
This includes the recent changes to enable a timeout/retry
that are required for #100