### PR TITLE
Add dns vip to baremetal platform

### DIFF
--- a/docs/user/metal/install_ipi.md
+++ b/docs/user/metal/install_ipi.md
@@ -137,6 +137,7 @@ controlPlane:
 platform:
   baremetal:
     apiVIP: 192.168.111.5
+    dnsVIP: 192.168.111.2
     hosts:
       - name: openshift-master-0
         role: master

--- a/pkg/types/baremetal/platform.go
+++ b/pkg/types/baremetal/platform.go
@@ -63,4 +63,7 @@ type Platform struct {
 
 	// IngressVIP is the VIP to use for ingress traffic
 	IngressVIP string `json:"ingressVIP"`
+
+	// DNSVIP is the VIP to use for internal DNS communication
+	DNSVIP     string `json:"dnsVIP"`
 }

--- a/pkg/types/baremetal/validation/platform.go
+++ b/pkg/types/baremetal/validation/platform.go
@@ -40,5 +40,9 @@ func ValidatePlatform(p *baremetal.Platform, fldPath *field.Path) field.ErrorLis
 	if err := validate.IP(p.IngressVIP); err != nil {
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("ingressVIP"), p.IngressVIP, err.Error()))
 	}
+
+	if err := validate.IP(p.DNSVIP); err != nil {
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("dnsVIP"), p.DNSVIP, err.Error()))
+	}
 	return allErrs
 }


### PR DESCRIPTION
This is a user-specified VIP like the API and ingress ones, and we
need it included in the baremetal platform data the same as they are.

Co-Authored-By: Yossi Boaron <yboaron@redhat.com>