### PR TITLE
pkg/tfvars/baremetal: check error return for bmc accessdetails

### DIFF
--- a/pkg/tfvars/baremetal/baremetal.go
+++ b/pkg/tfvars/baremetal/baremetal.go
@@ -46,7 +46,10 @@ func TFVars(libvirtURI, ironicURI, osImage, externalBridge, provisioningBridge s
 		}
 
 		// BMC Driver Info
-		accessDetails, _ := bmc.NewAccessDetails(host.BMC.Address)
+		accessDetails, err := bmc.NewAccessDetails(host.BMC.Address)
+		if err != nil {
+			return nil, err
+		}
 		credentials := bmc.Credentials{
 			Username: host.BMC.Username,
 			Password: host.BMC.Password,


### PR DESCRIPTION
Currently, if a user provides invalid BMC credentials (i.e. malformatted
or unsupported), we won't find out until much later. This adds error
checking.